### PR TITLE
76 - v3.1.8 Accounts API OBSupplementaryData1 rollback

### DIFF
--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5Basic.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5Basic.java
@@ -20,8 +20,6 @@ import io.swagger.annotations.ApiModelProperty;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Size;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -44,7 +42,7 @@ public class OBBeneficiary5Basic {
 
   @JsonProperty("SupplementaryData")
   @Valid
-  private Map<String, Object> supplementaryData = null;
+  private OBSupplementaryData1 supplementaryData = null;
 
   public OBBeneficiary5Basic accountId(String accountId) {
     this.accountId = accountId;
@@ -126,16 +124,8 @@ public class OBBeneficiary5Basic {
     this.reference = reference;
   }
 
-  public OBBeneficiary5Basic supplementaryData(Map<String, Object> supplementaryData) {
+  public OBBeneficiary5Basic supplementaryData(OBSupplementaryData1 supplementaryData) {
     this.supplementaryData = supplementaryData;
-    return this;
-  }
-
-  public OBBeneficiary5Basic putSupplementaryDataItem(String key, Object supplementaryDataItem) {
-    if (this.supplementaryData == null) {
-      this.supplementaryData = new HashMap<String, Object>();
-    }
-    this.supplementaryData.put(key, supplementaryDataItem);
     return this;
   }
 
@@ -147,11 +137,11 @@ public class OBBeneficiary5Basic {
   @ApiModelProperty(value = "Additional information that can not be captured in the structured fields and/or any other specific block.")
 
 
-  public Map<String, Object> getSupplementaryData() {
+  public OBSupplementaryData1 getSupplementaryData() {
     return supplementaryData;
   }
 
-  public void setSupplementaryData(Map<String, Object> supplementaryData) {
+  public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
     this.supplementaryData = supplementaryData;
   }
 

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5Detail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5Detail.java
@@ -21,8 +21,6 @@ import io.swagger.annotations.ApiModelProperty;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -45,7 +43,7 @@ public class OBBeneficiary5Detail {
 
   @JsonProperty("SupplementaryData")
   @Valid
-  private Map<String, Object> supplementaryData = null;
+  private OBSupplementaryData1 supplementaryData = null;
 
   @JsonProperty("CreditorAgent")
   private OBBranchAndFinancialInstitutionIdentification60 creditorAgent;
@@ -133,16 +131,8 @@ public class OBBeneficiary5Detail {
     this.reference = reference;
   }
 
-  public OBBeneficiary5Detail supplementaryData(Map<String, Object> supplementaryData) {
+  public OBBeneficiary5Detail supplementaryData(OBSupplementaryData1 supplementaryData) {
     this.supplementaryData = supplementaryData;
-    return this;
-  }
-
-  public OBBeneficiary5Detail putSupplementaryDataItem(String key, Object supplementaryDataItem) {
-    if (this.supplementaryData == null) {
-      this.supplementaryData = new HashMap<String, Object>();
-    }
-    this.supplementaryData.put(key, supplementaryDataItem);
     return this;
   }
 
@@ -154,11 +144,11 @@ public class OBBeneficiary5Detail {
   @ApiModelProperty(value = "Additional information that can not be captured in the structured fields and/or any other specific block.")
 
 
-  public Map<String, Object> getSupplementaryData() {
+  public OBSupplementaryData1 getSupplementaryData() {
     return supplementaryData;
   }
 
-  public void setSupplementaryData(Map<String, Object> supplementaryData) {
+  public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
     this.supplementaryData = supplementaryData;
   }
 

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductType.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductType.java
@@ -22,7 +22,9 @@ import io.swagger.annotations.ApiModelProperty;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Other product type details associated with the account.
@@ -58,7 +60,7 @@ public class OBReadProduct2DataOtherProductType {
 
     @JsonProperty("SupplementaryData")
     @Valid
-    private Map<String, Object> supplementaryData = null;
+    private OBSupplementaryData1 supplementaryData = null;
 
     public OBReadProduct2DataOtherProductType name(String name) {
         this.name = name;
@@ -230,16 +232,8 @@ public class OBReadProduct2DataOtherProductType {
         this.otherFeesCharges = otherFeesCharges;
     }
 
-    public OBReadProduct2DataOtherProductType supplementaryData(Map<String, Object> supplementaryData) {
+    public OBReadProduct2DataOtherProductType supplementaryData(OBSupplementaryData1 supplementaryData) {
         this.supplementaryData = supplementaryData;
-        return this;
-    }
-
-    public OBReadProduct2DataOtherProductType putSupplementaryDataItem(String key, Object supplementaryDataItem) {
-        if (this.supplementaryData == null) {
-            this.supplementaryData = new HashMap<String, Object>();
-        }
-        this.supplementaryData.put(key, supplementaryDataItem);
         return this;
     }
 
@@ -249,11 +243,11 @@ public class OBReadProduct2DataOtherProductType {
      * @return supplementaryData
      */
     @ApiModelProperty(value = "Additional information that can not be captured in the structured fields and/or any other specific block.")
-    public Map<String, Object> getSupplementaryData() {
+    public OBSupplementaryData1 getSupplementaryData() {
         return supplementaryData;
     }
 
-    public void setSupplementaryData(Map<String, Object> supplementaryData) {
+    public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
         this.supplementaryData = supplementaryData;
     }
 

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6Basic.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6Basic.java
@@ -23,8 +23,6 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -81,7 +79,7 @@ public class OBStandingOrder6Basic {
 
   @JsonProperty("SupplementaryData")
   @Valid
-  private Map<String, Object> supplementaryData = null;
+  private OBSupplementaryData1 supplementaryData = null;
 
   public OBStandingOrder6Basic accountId(String accountId) {
     this.accountId = accountId;
@@ -365,16 +363,8 @@ public class OBStandingOrder6Basic {
     this.finalPaymentAmount = finalPaymentAmount;
   }
 
-  public OBStandingOrder6Basic supplementaryData(Map<String, Object> supplementaryData) {
+  public OBStandingOrder6Basic supplementaryData(OBSupplementaryData1 supplementaryData) {
     this.supplementaryData = supplementaryData;
-    return this;
-  }
-
-  public OBStandingOrder6Basic putSupplementaryDataItem(String key, Object supplementaryDataItem) {
-    if (this.supplementaryData == null) {
-      this.supplementaryData = new HashMap<String, Object>();
-    }
-    this.supplementaryData.put(key, supplementaryDataItem);
     return this;
   }
 
@@ -386,11 +376,11 @@ public class OBStandingOrder6Basic {
   @ApiModelProperty(value = "Additional information that can not be captured in the structured fields and/or any other specific block.")
 
 
-  public Map<String, Object> getSupplementaryData() {
+  public OBSupplementaryData1 getSupplementaryData() {
     return supplementaryData;
   }
 
-  public void setSupplementaryData(Map<String, Object> supplementaryData) {
+  public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
     this.supplementaryData = supplementaryData;
   }
 

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6Detail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6Detail.java
@@ -23,8 +23,6 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -87,7 +85,7 @@ public class OBStandingOrder6Detail {
 
     @JsonProperty("SupplementaryData")
     @Valid
-    private Map<String, Object> supplementaryData = null;
+    private OBSupplementaryData1 supplementaryData = null;
 
     public OBStandingOrder6Detail accountId(String accountId) {
         this.accountId = accountId;
@@ -412,16 +410,8 @@ public class OBStandingOrder6Detail {
         this.creditorAccount = creditorAccount;
     }
 
-    public OBStandingOrder6Detail supplementaryData(Map<String, Object> supplementaryData) {
+    public OBStandingOrder6Detail supplementaryData(OBSupplementaryData1 supplementaryData) {
         this.supplementaryData = supplementaryData;
-        return this;
-    }
-
-    public OBStandingOrder6Detail putSupplementaryDataItem(String key, Object supplementaryDataItem) {
-        if (this.supplementaryData == null) {
-            this.supplementaryData = new HashMap<String, Object>();
-        }
-        this.supplementaryData.put(key, supplementaryDataItem);
         return this;
     }
 
@@ -431,11 +421,11 @@ public class OBStandingOrder6Detail {
      * @return supplementaryData
      */
     @ApiModelProperty(value = "Additional information that can not be captured in the structured fields and/or any other specific block.")
-    public Map<String, Object> getSupplementaryData() {
+    public OBSupplementaryData1 getSupplementaryData() {
         return supplementaryData;
     }
 
-    public void setSupplementaryData(Map<String, Object> supplementaryData) {
+    public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
         this.supplementaryData = supplementaryData;
     }
 

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6Basic.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6Basic.java
@@ -23,7 +23,9 @@ import org.joda.time.DateTime;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Provides further details on an entry in the report.
@@ -85,7 +87,7 @@ public class OBTransaction6Basic {
 
   @JsonProperty("SupplementaryData")
   @Valid
-  private Map<String, Object> supplementaryData = null;
+  private OBSupplementaryData1 supplementaryData = null;
 
   public OBTransaction6Basic accountId(String accountId) {
     this.accountId = accountId;
@@ -421,16 +423,8 @@ public class OBTransaction6Basic {
     this.cardInstrument = cardInstrument;
   }
 
-  public OBTransaction6Basic supplementaryData(Map<String, Object> supplementaryData) {
+  public OBTransaction6Basic supplementaryData(OBSupplementaryData1 supplementaryData) {
     this.supplementaryData = supplementaryData;
-    return this;
-  }
-
-  public OBTransaction6Basic putSupplementaryDataItem(String key, Object supplementaryDataItem) {
-    if (this.supplementaryData == null) {
-      this.supplementaryData = new HashMap<String, Object>();
-    }
-    this.supplementaryData.put(key, supplementaryDataItem);
     return this;
   }
 
@@ -442,11 +436,11 @@ public class OBTransaction6Basic {
   @ApiModelProperty(value = "Additional information that can not be captured in the structured fields and/or any other specific block.")
 
 
-  public Map<String, Object> getSupplementaryData() {
+  public OBSupplementaryData1 getSupplementaryData() {
     return supplementaryData;
   }
 
-  public void setSupplementaryData(Map<String, Object> supplementaryData) {
+  public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
     this.supplementaryData = supplementaryData;
   }
 

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6Detail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6Detail.java
@@ -23,7 +23,9 @@ import org.joda.time.DateTime;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Provides further details on an entry in the report.
@@ -106,7 +108,7 @@ public class OBTransaction6Detail {
 
   @JsonProperty("SupplementaryData")
   @Valid
-  private Map<String, Object> supplementaryData = null;
+  private OBSupplementaryData1 supplementaryData = null;
 
   public OBTransaction6Detail accountId(String accountId) {
     this.accountId = accountId;
@@ -582,16 +584,8 @@ public class OBTransaction6Detail {
     this.cardInstrument = cardInstrument;
   }
 
-  public OBTransaction6Detail supplementaryData(Map<String, Object> supplementaryData) {
+  public OBTransaction6Detail supplementaryData(OBSupplementaryData1 supplementaryData) {
     this.supplementaryData = supplementaryData;
-    return this;
-  }
-
-  public OBTransaction6Detail putSupplementaryDataItem(String key, Object supplementaryDataItem) {
-    if (this.supplementaryData == null) {
-      this.supplementaryData = new HashMap<String, Object>();
-    }
-    this.supplementaryData.put(key, supplementaryDataItem);
     return this;
   }
 
@@ -603,11 +597,11 @@ public class OBTransaction6Detail {
   @ApiModelProperty(value = "Additional information that can not be captured in the structured fields and/or any other specific block.")
 
 
-  public Map<String, Object> getSupplementaryData() {
+  public OBSupplementaryData1 getSupplementaryData() {
     return supplementaryData;
   }
 
-  public void setSupplementaryData(Map<String, Object> supplementaryData) {
+  public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
     this.supplementaryData = supplementaryData;
   }
 


### PR DESCRIPTION
### Accounts API OBSupplementaryData1 rollback

The benefit of overwriting existing classes is that you're less likely to miss changes to them, but it's not without risk. It looks like I shouldn't have changed `OBSupplementaryData1` to a `Map` (since we deliberately have `OBSupplementaryData1Serializer` and `OBSupplementaryData1Deserializer` for this).

**Issue**: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/76