### PR TITLE
Add accountId in FRAccountIdentifier

### DIFF
--- a/securebanking-openbanking-uk-forgerock-datamodel/src/main/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/account/FRFinancialAccount.java
+++ b/securebanking-openbanking-uk-forgerock-datamodel/src/main/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/account/FRFinancialAccount.java
@@ -54,6 +54,10 @@ public class FRFinancialAccount {
     private List<FRAccountIdentifier> accounts;
     private FRAccountServicer servicer;
 
+    public FRAccountIdentifier getFirstAccount() {
+        return this.accounts.get(0);
+    }
+
     public enum FRAccountStatusCode {
         DELETED("Deleted"),
         DISABLED("Disabled"),

--- a/securebanking-openbanking-uk-forgerock-datamodel/src/main/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/account/FRFinancialAccount.java
+++ b/securebanking-openbanking-uk-forgerock-datamodel/src/main/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/account/FRFinancialAccount.java
@@ -55,6 +55,8 @@ public class FRFinancialAccount {
     private FRAccountServicer servicer;
 
     public FRAccountIdentifier getFirstAccount() {
+        if(this.accounts == null || this.accounts.size()==0)
+            return null;
         return this.accounts.get(0);
     }
 

--- a/securebanking-openbanking-uk-forgerock-datamodel/src/main/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/common/FRAccountIdentifier.java
+++ b/securebanking-openbanking-uk-forgerock-datamodel/src/main/java/com/forgerock/securebanking/common/openbanking/uk/forgerock/datamodel/common/FRAccountIdentifier.java
@@ -38,5 +38,5 @@ public class FRAccountIdentifier {
     private String identification;
     private String name;
     private String secondaryIdentification;
-
+    private String accountId;
 }


### PR DESCRIPTION
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/297

### Implementation
- Add accountId field in FRAccountIdentifier class
- Create a method to get the first account from the list of FRAccountIdentifier in the FRFinancialAccount class