### PR TITLE
374: Create methods with only mandatory fields for International payment consent

### DIFF
--- a/securebanking-openbanking-uk-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBAccountTestDataFactory.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBAccountTestDataFactory.java
@@ -32,6 +32,13 @@ public class OBAccountTestDataFactory {
                 .secondaryIdentification("11");
     }
 
+    public static OBWriteDomestic2DataInitiationCreditorAccount aValidOBWriteDomestic2DataInitiationCreditorAccountMandatoryFields() {
+        return (new OBWriteDomestic2DataInitiationCreditorAccount())
+                .schemeName("UK.OBIE.SortCodeAccountNumber")
+                .identification("08080021325698")
+                .name("Mr Tim Burgess");
+    }
+
     public static OBWriteDomestic2DataInitiationDebtorAccount aValidOBWriteDomestic2DataInitiationDebtorAccount() {
         return (new OBWriteDomestic2DataInitiationDebtorAccount())
                 .schemeName("UK.OBIE.SortCodeAccountNumber")

--- a/securebanking-openbanking-uk-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteInternationalConsentTestDataFactory.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteInternationalConsentTestDataFactory.java
@@ -23,12 +23,12 @@ import static uk.org.openbanking.testsupport.payment.OBAccountTestDataFactory.*;
 import static uk.org.openbanking.testsupport.payment.OBAmountTestDataFactory.aValidOBActiveOrHistoricCurrencyAndAmount;
 import static uk.org.openbanking.testsupport.payment.OBAmountTestDataFactory.aValidOBWriteDomestic2DataInitiationInstructedAmount;
 import static uk.org.openbanking.testsupport.payment.OBConsentAuthorisationTestDataFactory.*;
-import static uk.org.openbanking.testsupport.payment.OBExchangeRateTestDataFactory.aValidOBExchangeRate1;
-import static uk.org.openbanking.testsupport.payment.OBExchangeRateTestDataFactory.aValidOBWriteInternational3DataInitiationExchangeRateInformation;
+import static uk.org.openbanking.testsupport.payment.OBExchangeRateTestDataFactory.*;
 import static uk.org.openbanking.testsupport.payment.OBInternationalIdentifierTestDataFactory.*;
 import static uk.org.openbanking.testsupport.payment.OBRemittanceInformationTestDataFactory.aValidOBRemittanceInformation1;
 import static uk.org.openbanking.testsupport.payment.OBRemittanceInformationTestDataFactory.aValidOBWriteDomestic2DataInitiationRemittanceInformation;
 import static uk.org.openbanking.testsupport.payment.OBRisk1TestDataFactory.aValidOBRisk1;
+import static uk.org.openbanking.testsupport.payment.OBRisk1TestDataFactory.aValidOBRisk1MandatoryFields;
 import static uk.org.openbanking.testsupport.payment.OBWriteDomesticScaSupportDataTestDataFactory.aValidOBSCASupportData1;
 import static uk.org.openbanking.testsupport.payment.OBWriteDomesticScaSupportDataTestDataFactory.aValidOBWriteDomesticConsent3DataSCASupportData;
 
@@ -49,10 +49,34 @@ public class OBWriteInternationalConsentTestDataFactory {
                 .risk(aValidOBRisk1());
     }
 
+    public static OBWriteInternationalConsent2 aValidOBWriteInternationalConsent2MandatoryFields() {
+        return (new OBWriteInternationalConsent2())
+                .data(aValidOBWriteDataInternationalConsent2MandatoryFields())
+                .risk(aValidOBRisk1MandatoryFields());
+    }
+
+    public static OBWriteInternationalConsent3 aValidOBWriteInternationalConsent3() {
+        return (new OBWriteInternationalConsent3())
+                .data(aValidOBWriteInternationalConsent3Data())
+                .risk(aValidOBRisk1());
+    }
+
+    public static OBWriteInternationalConsent3 aValidOBWriteInternationalConsent3MandatoryFields() {
+        return (new OBWriteInternationalConsent3())
+                .data(aValidOBWriteInternationalConsent3DataMandatoryFields())
+                .risk(aValidOBRisk1MandatoryFields());
+    }
+
     public static OBWriteInternationalConsent4 aValidOBWriteInternationalConsent4() {
         return (new OBWriteInternationalConsent4())
                 .data(aValidOBWriteInternationalConsent4Data())
                 .risk(aValidOBRisk1());
+    }
+
+    public static OBWriteInternationalConsent4 aValidOBWriteInternationalConsent4MandatoryFields() {
+        return (new OBWriteInternationalConsent4())
+                .data(aValidOBWriteInternationalConsent4DataMandatoryFields())
+                .risk(aValidOBRisk1MandatoryFields());
     }
 
     public static OBWriteInternationalConsent5 aValidOBWriteInternationalConsent5() {
@@ -61,10 +85,32 @@ public class OBWriteInternationalConsentTestDataFactory {
                 .risk(aValidOBRisk1());
     }
 
+    public static OBWriteInternationalConsent5 aValidOBWriteInternationalConsent5MandatoryFields() {
+        return (new OBWriteInternationalConsent5())
+                .data(aValidOBWriteInternationalConsent5DataMandatoryFields())
+                .risk(aValidOBRisk1MandatoryFields());
+    }
+
     public static OBWriteDataInternationalConsent2 aValidOBWriteDataInternationalConsent2() {
         return (new OBWriteDataInternationalConsent2())
                 .initiation(aValidOBInternational2())
                 .authorisation(aValidOBAuthorisation1());
+    }
+
+    public static OBWriteDataInternationalConsent2 aValidOBWriteDataInternationalConsent2MandatoryFields() {
+        return (new OBWriteDataInternationalConsent2())
+                .initiation(aValidOBInternational2MandatoryFields());
+    }
+
+    public static OBWriteInternationalConsent3Data aValidOBWriteInternationalConsent3Data() {
+        return (new OBWriteInternationalConsent3Data())
+                .initiation(aValidOBWriteInternational2DataInitiation())
+                .authorisation(aValidOBWriteDomesticConsent3DataAuthorisation());
+    }
+
+    public static OBWriteInternationalConsent3Data aValidOBWriteInternationalConsent3DataMandatoryFields() {
+        return (new OBWriteInternationalConsent3Data())
+                .initiation(aValidOBWriteInternational2DataInitiationMandatoryFields());
     }
 
     public static OBWriteInternationalConsent4Data aValidOBWriteInternationalConsent4Data() {
@@ -74,12 +120,22 @@ public class OBWriteInternationalConsentTestDataFactory {
                 .scASupportData(aValidOBWriteDomesticConsent3DataSCASupportData());
     }
 
+    public static OBWriteInternationalConsent4Data aValidOBWriteInternationalConsent4DataMandatoryFields() {
+        return (new OBWriteInternationalConsent4Data())
+                .initiation(aValidOBWriteInternational3DataInitiationMandatoryFields());
+    }
+
     public static OBWriteInternationalConsent5Data aValidOBWriteInternationalConsent5Data() {
         return (new OBWriteInternationalConsent5Data())
                 .initiation(aValidOBWriteInternational3DataInitiation())
                 .authorisation(aValidOBWriteDomesticConsent4DataAuthorisation())
                 .scASupportData(aValidOBSCASupportData1())
                 .readRefundAccount(OBReadRefundAccountEnum.NO);
+    }
+
+    public static OBWriteInternationalConsent5Data aValidOBWriteInternationalConsent5DataMandatoryFields() {
+        return (new OBWriteInternationalConsent5Data())
+                .initiation(aValidOBWriteInternational3DataInitiationMandatoryFields());
     }
 
     public static OBInternational1 aValidOBInternational1() {
@@ -119,6 +175,43 @@ public class OBWriteInternationalConsentTestDataFactory {
                 .supplementaryData(new OBSupplementaryData1());
     }
 
+    public static OBInternational2 aValidOBInternational2MandatoryFields() {
+        return (new OBInternational2())
+                .instructionIdentification(INSTRUCTION_IDENTIFICATION)
+                .endToEndIdentification(END_TO_END_IDENTIFICATION)
+                .currencyOfTransfer(CURRENCY)
+                .instructedAmount(aValidOBActiveOrHistoricCurrencyAndAmount())
+                .creditorAccount(aValidOBCashAccount3());
+    }
+
+    public static OBWriteInternational2DataInitiation aValidOBWriteInternational2DataInitiation() {
+        return (new OBWriteInternational2DataInitiation())
+                .instructionIdentification(INSTRUCTION_IDENTIFICATION)
+                .endToEndIdentification(END_TO_END_IDENTIFICATION)
+                .localInstrument(LOCAL_INSTRUMENT)
+                .instructionPriority(OBPriority2Code.NORMAL)
+                .purpose(PURPOSE)
+                .chargeBearer(OBChargeBearerType1Code.SHARED)
+                .currencyOfTransfer(CURRENCY)
+                .instructedAmount(aValidOBWriteDomestic2DataInitiationInstructedAmount())
+                .exchangeRateInformation(aValidOBWriteInternational2DataInitiationExchangeRateInformation())
+                .debtorAccount(aValidOBWriteDomestic2DataInitiationDebtorAccount())
+                .creditor(aValidOBWriteInternational2DataInitiationCreditor())
+                .creditorAgent(aValidOBWriteInternational2DataInitiationCreditorAgent())
+                .creditorAccount(aValidOBWriteDomestic2DataInitiationCreditorAccount())
+                .remittanceInformation(aValidOBWriteDomestic2DataInitiationRemittanceInformation())
+                .supplementaryData(new OBSupplementaryData1());
+    }
+
+    public static OBWriteInternational2DataInitiation aValidOBWriteInternational2DataInitiationMandatoryFields() {
+        return (new OBWriteInternational2DataInitiation())
+                .instructionIdentification(INSTRUCTION_IDENTIFICATION)
+                .endToEndIdentification(END_TO_END_IDENTIFICATION)
+                .currencyOfTransfer(CURRENCY)
+                .instructedAmount(aValidOBWriteDomestic2DataInitiationInstructedAmount())
+                .creditorAccount(aValidOBWriteDomestic2DataInitiationCreditorAccount());
+    }
+
     public static OBWriteInternational3DataInitiation aValidOBWriteInternational3DataInitiation() {
         return (new OBWriteInternational3DataInitiation())
                 .instructionIdentification(INSTRUCTION_IDENTIFICATION)
@@ -138,5 +231,14 @@ public class OBWriteInternationalConsentTestDataFactory {
                 .creditorAccount(aValidOBWriteDomestic2DataInitiationCreditorAccount())
                 .remittanceInformation(aValidOBWriteDomestic2DataInitiationRemittanceInformation())
                 .supplementaryData(new OBSupplementaryData1());
+    }
+
+    public static OBWriteInternational3DataInitiation aValidOBWriteInternational3DataInitiationMandatoryFields() {
+        return (new OBWriteInternational3DataInitiation())
+                .instructionIdentification(INSTRUCTION_IDENTIFICATION)
+                .endToEndIdentification(END_TO_END_IDENTIFICATION)
+                .currencyOfTransfer(CURRENCY)
+                .instructedAmount(aValidOBWriteDomestic2DataInitiationInstructedAmount())
+                .creditorAccount(aValidOBWriteDomestic2DataInitiationCreditorAccountMandatoryFields());
     }
 }


### PR DESCRIPTION
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/374