### PR TITLE
450: Preventing the codegen from using JsonNullable

### DIFF
--- a/securebanking-openbanking-uk-obie-datamodel/pom.xml
+++ b/securebanking-openbanking-uk-obie-datamodel/pom.xml
@@ -175,6 +175,7 @@
                                     <generateApis>false</generateApis>
                                     <configOptions>
                                         <dateLibrary>joda</dateLibrary>
+                                        <openApiNullable>false</openApiNullable>
                                     </configOptions>
                                     <addCompileSourceRoot>false</addCompileSourceRoot>
                                 </configuration>


### PR DESCRIPTION
Currently, the codegen produces output which includes an unused import for JsonNullable. This causes issues as this class is not on the classpath and therefore causes compilation errors. Disabling support for JsonNullable as we don't use this functionality and it seems unlikely that we would want to in the future.

More information on JsonNullable can be found here: https://github.com/OpenAPITools/jackson-databind-nullable

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/446