### PR TITLE
451: Removing timestamp from generated code annotation

### DIFF
--- a/securebanking-openbanking-uk-obie-datamodel/pom.xml
+++ b/securebanking-openbanking-uk-obie-datamodel/pom.xml
@@ -176,6 +176,7 @@
                                     <configOptions>
                                         <dateLibrary>joda</dateLibrary>
                                         <openApiNullable>false</openApiNullable>
+                                        <hideGenerationTimestamp>true</hideGenerationTimestamp>
                                     </configOptions>
                                     <addCompileSourceRoot>false</addCompileSourceRoot>
                                 </configuration>

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/BCA.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/BCA.java
@@ -39,7 +39,7 @@ import java.util.Objects;
 /**
  * BCA
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T15:59:01.633+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class BCA {
     @JsonProperty("ProductDetails")
     private ProductDetails productDetails = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/BCAFeeChargeCap.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/BCAFeeChargeCap.java
@@ -46,7 +46,7 @@ import java.util.Objects;
  * Details about any caps (maximum charges) that apply to a particular or group of fee/charge
  */
 @ApiModel(description = "Details about any caps (maximum charges) that apply to a particular or group of fee/charge")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T15:59:01.633+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class BCAFeeChargeCap {
     @JsonProperty("FeeType")
     private List<FeeTypeEnum> feeType = new ArrayList<FeeTypeEnum>();

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/BCAFeeChargeDetail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/BCAFeeChargeDetail.java
@@ -45,7 +45,7 @@ import java.util.Objects;
  * Other fees/charges details
  */
 @ApiModel(description = "Other fees/charges details")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T15:59:01.633+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class BCAFeeChargeDetail {
     @JsonProperty("FeeCategory")
     private FeeCategoryEnum feeCategory = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/BCAOtherFeesCharges.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/BCAOtherFeesCharges.java
@@ -45,7 +45,7 @@ import java.util.Objects;
  * Contains details of fees and charges which are not associated with either Overdraft or features/benefits
  */
 @ApiModel(description = "Contains details of fees and charges which are not associated with either Overdraft or features/benefits")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T15:59:01.633+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class BCAOtherFeesCharges {
     @JsonProperty("TariffType")
     private TariffTypeEnum tariffType = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterest.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterest.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Details about the interest that may be payable to the BCA account holders
  */
 @ApiModel(description = "Details about the interest that may be payable to the BCA account holders")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class CreditInterest {
   @JsonProperty("TierBandSet")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterest1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterest1.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Details about the interest that may be payable to the PCA account holders
  */
 @ApiModel(description = "Details about the interest that may be payable to the PCA account holders")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class CreditInterest1 {
   @JsonProperty("TierBandSet")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterest1TierBand.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterest1TierBand.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * Tier Band Details
  */
 @ApiModel(description = "Tier Band Details")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class CreditInterest1TierBand {
     @JsonProperty("Identification")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterest1TierBandSet.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterest1TierBandSet.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  * The group of tiers or bands for which credit interest can be applied.
  */
 @ApiModel(description = "The group of tiers or bands for which credit interest can be applied.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class CreditInterest1TierBandSet {
   /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterestTierBand.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterestTierBand.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * Tier Band Details
  */
 @ApiModel(description = "Tier Band Details")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class CreditInterestTierBand {
     @JsonProperty("Identification")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterestTierBandSet.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/CreditInterestTierBandSet.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  * The group of tiers or bands for which credit interest can be applied.
  */
 @ApiModel(description = "The group of tiers or bands for which credit interest can be applied.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class CreditInterestTierBandSet {
     /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeApplicableRange.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/FeeApplicableRange.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  * Range or amounts or rates for which the fee/charge applies
  */
 @ApiModel(description = "Range or amounts or rates for which the fee/charge applies")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class FeeApplicableRange {
   @JsonProperty("MinimumAmount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount1.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Account
  */
 @ApiModel(description = "Account")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-16T08:37:28.078Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBAccount1 {
     @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount2.java
@@ -34,7 +34,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Unambiguous identification of the account to which credit and debit entries are made.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBAccount2 {
     @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount2Account.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount2Account.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Provides the details to identify an account.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBAccount2Account   {
 

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount2Basic.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount2Basic.java
@@ -31,7 +31,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Unambiguous identification of the account to which credit and debit entries are made.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBAccount2Basic   {
   @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount3.java
@@ -45,7 +45,7 @@ import java.util.Objects;
  * Unambiguous identification of the account to which credit and debit entries are made.
  */
 @ApiModel(description = "Unambiguous identification of the account to which credit and debit entries are made.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBAccount3 {
     @JsonProperty("AccountId")
     private String accountId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount3Account.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount3Account.java
@@ -40,7 +40,7 @@ import java.util.Objects;
  * Provides the details to identify an account.
  */
 @ApiModel(description = "Provides the details to identify an account.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T15:59:01.633+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBAccount3Account {
     @JsonProperty("SchemeName")
     private String schemeName = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount3Basic.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount3Basic.java
@@ -42,7 +42,7 @@ import java.util.Objects;
  * Unambiguous identification of the account to which credit and debit entries are made.
  */
 @ApiModel(description = "Unambiguous identification of the account to which credit and debit entries are made.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBAccount3Basic {
     @JsonProperty("AccountId")
     private String accountId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount3Detail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount3Detail.java
@@ -44,7 +44,7 @@ import java.util.Objects;
  * Unambiguous identification of the account to which credit and debit entries are made.
  */
 @ApiModel(description = "Unambiguous identification of the account to which credit and debit entries are made.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBAccount3Detail {
     @JsonProperty("AccountId")
     private String accountId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount4.java
@@ -44,7 +44,7 @@ import java.util.Objects;
  * Unambiguous identification of the account to which credit and debit entries are made.
  */
 @ApiModel(description = "Unambiguous identification of the account to which credit and debit entries are made.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2021-05-05T09:20:17.613+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBAccount4 {
     @JsonProperty("Account")
     private List<OBAccount4Account> account = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount4Account.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount4Account.java
@@ -40,7 +40,7 @@ import java.util.Objects;
  * Provides the details to identify an account.
  */
 @ApiModel(description = "Provides the details to identify an account.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2021-05-05T09:20:17.613+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBAccount4Account {
     @JsonProperty("Identification")
     private String identification = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount4Basic.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount4Basic.java
@@ -42,7 +42,7 @@ import java.util.Objects;
  * Unambiguous identification of the account to which credit and debit entries are made.
  */
 @ApiModel(description = "Unambiguous identification of the account to which credit and debit entries are made.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2021-05-05T09:20:17.613+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBAccount4Basic {
     @JsonProperty("AccountId")
     private String accountId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount4Detail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount4Detail.java
@@ -44,7 +44,7 @@ import java.util.Objects;
  * Unambiguous identification of the account to which credit and debit entries are made.
  */
 @ApiModel(description = "Unambiguous identification of the account to which credit and debit entries are made.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2021-05-05T09:20:17.613+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBAccount4Detail {
     @JsonProperty("Account")
     private List<OBAccount4Account> account = new ArrayList<OBAccount4Account>();

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  * Unambiguous identification of the account to which credit and debit entries are made. The following fields are optional only for accounts that are switched:    * Data.Currency     * Data.AccountType     * Data.AccountSubType  For all other accounts, the fields must be populated by the ASPSP.
  */
 @ApiModel(description = "Unambiguous identification of the account to which credit and debit entries are made. The following fields are optional only for accounts that are switched:    * Data.Currency     * Data.AccountType     * Data.AccountSubType  For all other accounts, the fields must be populated by the ASPSP.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBAccount6 {
   @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6Account.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6Account.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Provides the details to identify an account.
  */
 @ApiModel(description = "Provides the details to identify an account.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBAccount6Account {
   @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6Basic.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6Basic.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Unambiguous identification of the account to which credit and debit entries are made.
  */
 @ApiModel(description = "Unambiguous identification of the account to which credit and debit entries are made.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBAccount6Basic {
     @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6Detail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBAccount6Detail.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  * Unambiguous identification of the account to which credit and debit entries are made.
  */
 @ApiModel(description = "Unambiguous identification of the account to which credit and debit entries are made.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBAccount6Detail {
     @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount0.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount0.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * The amount of the most recent direct debit collection.
  */
 @ApiModel(description = "The amount of the most recent direct debit collection.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBActiveOrHistoricCurrencyAndAmount0 {
     @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount1.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party. Usage: This amount has to be transported unchanged through the transaction chain.
  */
 @ApiModel(description = "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party. Usage: This amount has to be transported unchanged through the transaction chain.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBActiveOrHistoricCurrencyAndAmount1 {
     @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount10.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount10.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Transaction charges to be paid by the charge bearer.
  */
 @ApiModel(description = "Transaction charges to be paid by the charge bearer.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBActiveOrHistoricCurrencyAndAmount10 {
     @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount11.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount11.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * The amount of the last (most recent) Standing Order instruction.
  */
 @ApiModel(description = "The amount of the last (most recent) Standing Order instruction.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBActiveOrHistoricCurrencyAndAmount11 {
     @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount2.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * The amount of the first Standing Order
  */
 @ApiModel(description = "The amount of the first Standing Order")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBActiveOrHistoricCurrencyAndAmount2 {
   @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount3.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * The amount of the next Standing Order.
  */
 @ApiModel(description = "The amount of the next Standing Order.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBActiveOrHistoricCurrencyAndAmount3 {
   @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount4.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * The amount of the final Standing Order
  */
 @ApiModel(description = "The amount of the final Standing Order")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBActiveOrHistoricCurrencyAndAmount4 {
   @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount5.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Amount of money associated with the statement benefit type.
  */
 @ApiModel(description = "Amount of money associated with the statement benefit type.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBActiveOrHistoricCurrencyAndAmount5 {
     @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount6.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount6.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Amount of money associated with the statement fee type.
  */
 @ApiModel(description = "Amount of money associated with the statement fee type.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBActiveOrHistoricCurrencyAndAmount6 {
   @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount7.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount7.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Amount of money associated with the statement interest amount type.
  */
 @ApiModel(description = "Amount of money associated with the statement interest amount type.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBActiveOrHistoricCurrencyAndAmount7 {
   @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount8.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount8.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Amount of money associated with the amount type.
  */
 @ApiModel(description = "Amount of money associated with the amount type.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBActiveOrHistoricCurrencyAndAmount8 {
   @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount9.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBActiveOrHistoricCurrencyAndAmount9.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Amount of money in the cash transaction entry.
  */
 @ApiModel(description = "Amount of money in the cash transaction entry.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBActiveOrHistoricCurrencyAndAmount9 {
   @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAData1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAData1.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * OBBCAData1
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBBCAData1 {
     @JsonProperty("ProductDetails")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAData1FeeChargeCap.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAData1FeeChargeCap.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * Details about any caps (maximum charges) that apply to a particular or group of fee/charge
  */
 @ApiModel(description = "Details about any caps (maximum charges) that apply to a particular or group of fee/charge")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBBCAData1FeeChargeCap {
     /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAData1FeeChargeDetail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAData1FeeChargeDetail.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  * Other fees/charges details
  */
 @ApiModel(description = "Other fees/charges details")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBBCAData1FeeChargeDetail {
     /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAData1OtherFeeType.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAData1OtherFeeType.java
@@ -41,7 +41,7 @@ import java.util.Objects;
  * Other fee type code which is not available in the standard code set
  */
 @ApiModel(description = "Other fee type code which is not available in the standard code set")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2021-05-05T09:20:17.613+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBBCAData1OtherFeeType {
     @JsonProperty("Code")
     private String code = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAData1OtherFeesCharges.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAData1OtherFeesCharges.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  * Contains details of fees and charges which are not associated with either Overdraft or features/benefits
  */
 @ApiModel(description = "Contains details of fees and charges which are not associated with either Overdraft or features/benefits")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBBCAData1OtherFeesCharges {
   /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAProductDetails1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBCAProductDetails1.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * OBBCAProductDetails1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBBCAProductDetails1 {
 

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBankTransactionCodeStructure1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBankTransactionCodeStructure1.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  * Set of elements used to fully identify the type of underlying transaction resulting in an entry.
  */
 @ApiModel(description = "Set of elements used to fully identify the type of underlying transaction resulting in an entry.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBBankTransactionCodeStructure1 {
     @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary1.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Beneficiary
  */
 @ApiModel(description = "Beneficiary")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-16T08:37:28.078Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBBeneficiary1 {
     @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary2.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * OBBeneficiary2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBBeneficiary2 {
     @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary3.java
@@ -39,7 +39,7 @@ import java.util.Objects;
 /**
  * OBBeneficiary3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBBeneficiary3 {
     @JsonProperty("AccountId")
     private String accountId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary3Basic.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary3Basic.java
@@ -37,7 +37,7 @@ import java.util.Objects;
 /**
  * OBBeneficiary3Basic
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBBeneficiary3Basic {
     @JsonProperty("AccountId")
     private String accountId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary3Detail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary3Detail.java
@@ -40,7 +40,7 @@ import java.util.Objects;
 /**
  * OBBeneficiary3Detail
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBBeneficiary3Detail {
     @JsonProperty("AccountId")
     private String accountId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary4.java
@@ -39,7 +39,7 @@ import java.util.Objects;
 /**
  * OBBeneficiary4
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T10:29:01.751+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBBeneficiary4 {
     @JsonProperty("AccountId")
     private String accountId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary4Basic.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary4Basic.java
@@ -39,7 +39,7 @@ import java.util.Objects;
 /**
  * OBBeneficiary4Basic
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T10:29:01.751+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBBeneficiary4Basic {
     @JsonProperty("AccountId")
     private String accountId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary4Detail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary4Detail.java
@@ -40,7 +40,7 @@ import java.util.Objects;
 /**
  * OBBeneficiary4Detail
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T10:29:01.751+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBBeneficiary4Detail {
     @JsonProperty("AccountId")
     private String accountId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * OBBeneficiary5
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBBeneficiary5 {
   @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5Basic.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5Basic.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * OBBeneficiary5Basic
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBBeneficiary5Basic {
   @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5Detail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5Detail.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * OBBeneficiary5Detail
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBBeneficiary5Detail {
   @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification3.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Financial institution servicing an account for the debtor.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBBranchAndFinancialInstitutionIdentification3 {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification4.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBBranchAndFinancialInstitutionIdentification4 {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification5.java
@@ -40,7 +40,7 @@ import java.util.Objects;
  * Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account.
  */
 @ApiModel(description = "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBBranchAndFinancialInstitutionIdentification5 {
     @JsonProperty("SchemeName")
     private String schemeName = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification50.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification50.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account.
  */
 @ApiModel(description = "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBBranchAndFinancialInstitutionIdentification50 {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification51.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification51.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account.
  */
 @ApiModel(description = "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBBranchAndFinancialInstitutionIdentification51 {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification60.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification60.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account.
  */
 @ApiModel(description = "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBBranchAndFinancialInstitutionIdentification60 {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification61.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification61.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Financial institution servicing an account for the creditor.
  */
 @ApiModel(description = "Financial institution servicing an account for the creditor.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBBranchAndFinancialInstitutionIdentification61 {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification62.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBBranchAndFinancialInstitutionIdentification62.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Financial institution servicing an account for the debtor.
  */
 @ApiModel(description = "Financial institution servicing an account for the debtor.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBBranchAndFinancialInstitutionIdentification62 {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount1.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Provides the details to identify an account.
  */
 @ApiModel(description = "Provides the details to identify an account.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-16T08:37:28.078Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBCashAccount1 {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount2.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * OBCashAccount2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBCashAccount2 {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount5.java
@@ -40,7 +40,7 @@ import java.util.Objects;
  * Provides the details to identify the beneficiary account.
  */
 @ApiModel(description = "Provides the details to identify the beneficiary account.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBCashAccount5 {
     @JsonProperty("SchemeName")
     private String schemeName = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount50.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount50.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Provides the details to identify the beneficiary account.
  */
 @ApiModel(description = "Provides the details to identify the beneficiary account.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBCashAccount50 {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount51.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount51.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Provides the details to identify the beneficiary account.
  */
 @ApiModel(description = "Provides the details to identify the beneficiary account.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBCashAccount51 {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount6.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount6.java
@@ -39,7 +39,7 @@ import java.util.Objects;
  * Unambiguous identification of the account of the debtor, in the case of a crebit transaction.
  */
 @ApiModel(description = "Unambiguous identification of the account of the debtor, in the case of a crebit transaction.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBCashAccount6 {
     @JsonProperty("SchemeName")
     private String schemeName = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount60.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount60.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  * Unambiguous identification of the account of the creditor, in the case of a debit transaction.
  */
 @ApiModel(description = "Unambiguous identification of the account of the creditor, in the case of a debit transaction.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBCashAccount60 {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount61.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashAccount61.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  * Unambiguous identification of the account of the debtor, in the case of a crebit transaction.
  */
 @ApiModel(description = "Unambiguous identification of the account of the debtor, in the case of a crebit transaction.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBCashAccount61 {
   @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashBalance1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCashBalance1.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Set of elements used to define the balance details.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBCashBalance1 {
     @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCreditInterest1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCreditInterest1.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Details about the interest that may be payable to the BCA account holders")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBCreditInterest1 {
   @JsonProperty("TierBandSet")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCreditLine1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCreditLine1.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Set of elements used to provide details on the credit line.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBCreditLine1 {
     @JsonProperty("Included")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCurrencyExchange5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCurrencyExchange5.java
@@ -31,7 +31,7 @@ import java.util.Objects;
  * Set of elements used to provide details on the currency exchange.
  */
 @ApiModel(description = "Set of elements used to provide details on the currency exchange.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBCurrencyExchange5 {
     @JsonProperty("SourceCurrency")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCurrencyExchange5InstructedAmount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBCurrencyExchange5InstructedAmount.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.
  */
 @ApiModel(description = "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBCurrencyExchange5InstructedAmount {
     @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBDirectDebit1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBDirectDebit1.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Account to or from which a cash entry is made.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBDirectDebit1 {
     @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBEquivalentAmount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBEquivalentAmount.java
@@ -31,7 +31,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Amount of money to be transferred between the debtor and creditor, before deduction of charges, expressed in the currency of the debtor's account, and to be transferred into a different currency.  Usage : Currency of the amount is expressed in the currency of the debtor's account, but the amount to be transferred is in another currency. The debtor agent will convert the amount and currency to the to be transferred amount and currency, eg, 'pay equivalent of 100000 EUR in JPY'(and account is in EUR).")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBEquivalentAmount {
     @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeApplicableRange1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeApplicableRange1.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Range or amounts or rates for which the fee/charge applies")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBFeeApplicableRange1 {
   @JsonProperty("MinimumAmount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeChargeCap1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeChargeCap1.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Details about any caps (maximum charges) that apply to a particular or group of fee/charge")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBFeeChargeCap1 {
 

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeChargeDetail1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBFeeChargeDetail1.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Other fees/charges details")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBFeeChargeDetail1 {
 

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterest1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterest1.java
@@ -43,7 +43,7 @@ import java.util.Objects;
  * Details about the interest that may be payable to the SME Loan holders
  */
 @ApiModel(description = "Details about the interest that may be payable to the SME Loan holders")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBLoanInterest1 {
     @JsonProperty("Notes")
     private List<String> notes = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterestFeesChargeCap1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterestFeesChargeCap1.java
@@ -43,7 +43,7 @@ import java.util.Objects;
  * Details about any caps (minimum/maximum charges) that apply to a particular fee/charge
  */
 @ApiModel(description = "Details about any caps (minimum/maximum charges) that apply to a particular fee/charge")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBLoanInterestFeesChargeCap1 {
     @JsonProperty("FeeType")
     private List<OBFeeType1Code> feeType = new ArrayList<OBFeeType1Code>();

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterestFeesChargeDetail1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterestFeesChargeDetail1.java
@@ -43,7 +43,7 @@ import java.util.Objects;
  * Other fees/charges details
  */
 @ApiModel(description = "Other fees/charges details")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBLoanInterestFeesChargeDetail1 {
     @JsonProperty("FeeType")
     private OBFeeType1Code feeType = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterestFeesCharges1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterestFeesCharges1.java
@@ -43,7 +43,7 @@ import java.util.Objects;
  * Contains details of fees and charges which are not associated with either LoanRepayment or features/benefits
  */
 @ApiModel(description = "Contains details of fees and charges which are not associated with either LoanRepayment or features/benefits")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBLoanInterestFeesCharges1 {
     @JsonProperty("LoanInterestFeeChargeDetail")
     private List<OBLoanInterestFeesChargeDetail1> loanInterestFeeChargeDetail = new ArrayList<OBLoanInterestFeesChargeDetail1>();

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterestTierBand1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterestTierBand1.java
@@ -44,7 +44,7 @@ import java.util.Objects;
  * Tier Band Details
  */
 @ApiModel(description = "Tier Band Details")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBLoanInterestTierBand1 {
     @JsonProperty("Identification")
     private String identification = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterestTierBandSet1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBLoanInterestTierBandSet1.java
@@ -43,7 +43,7 @@ import java.util.Objects;
  * The group of tiers or bands for which debit interest can be applied.
  */
 @ApiModel(description = "The group of tiers or bands for which debit interest can be applied.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBLoanInterestTierBandSet1 {
     @JsonProperty("TierBandMethod")
     private OBTierBandType1Code tierBandMethod = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBMerchantDetails1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBMerchantDetails1.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  * Details of the merchant involved in the transaction.
  */
 @ApiModel(description = "Details of the merchant involved in the transaction.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBMerchantDetails1 {
     @JsonProperty("MerchantName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOffer1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOffer1.java
@@ -31,7 +31,7 @@ import java.util.Objects;
  * OBOffer1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBOffer1 {
     @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType1.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Other interest rate types which are not available in the standard code list")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBOtherCodeType1 {
   @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType10.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType10.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * OBOtherCodeType10
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBOtherCodeType10 {
     @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType11.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType11.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other application frequencies that are not available in the standard code list
  */
 @ApiModel(description = "Other application frequencies that are not available in the standard code list")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBOtherCodeType11 {
     @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType12.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType12.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other calculation frequency which is not available in the standard code set.
  */
 @ApiModel(description = "Other calculation frequency which is not available in the standard code set.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBOtherCodeType12 {
     @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType13.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType13.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other Fee type which is not available in the standard code set
  */
 @ApiModel(description = "Other Fee type which is not available in the standard code set")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBOtherCodeType13 {
     @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType14.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType14.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other fee rate type code which is not available in the standard code set
  */
 @ApiModel(description = "Other fee rate type code which is not available in the standard code set")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBOtherCodeType14 {
     @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType15.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType15.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other fee rate type which is not in the standard rate type list
  */
 @ApiModel(description = "Other fee rate type which is not in the standard rate type list")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBOtherCodeType15 {
     @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType16.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType16.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other application frequencies not covered in the standard code list
  */
 @ApiModel(description = "Other application frequencies not covered in the standard code list")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBOtherCodeType16   {
   @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType17.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType17.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other calculation frequency which is not available in standard code set.
  */
 @ApiModel(description = "Other calculation frequency which is not available in standard code set.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBOtherCodeType17 {
     @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType18.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherCodeType18.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other fee rate type which is not available in the standard code set
  */
 @ApiModel(description = "Other fee rate type which is not available in the standard code set")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBOtherCodeType18 {
     @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherFeeChargeDetailType.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherFeeChargeDetailType.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * Other Fee/charge type which is not available in the standard code set
  */
 @ApiModel(description = "Other Fee/charge type which is not available in the standard code set")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBOtherFeeChargeDetailType {
     @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherFeesAndCharges1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherFeesAndCharges1.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Contains details of fees and charges which are not associated with either Overdraft or features/benefits")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBOtherFeesAndCharges1 {
 

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherProductDetails1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherProductDetails1.java
@@ -39,7 +39,7 @@ import java.util.Objects;
 /**
  * OBOtherProductDetails1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBOtherProductDetails1 {
     @JsonProperty("Segment")
     private List<OBOtherProductSegment1Code> segment = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherProductType1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOtherProductType1.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "This field provides extension to the ProductType enumeration. If ProductType - \"Other\" is chosen, this field must be populated with name, and description for ASPSP specific product type.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBOtherProductType1   {
   @JsonProperty("Name")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraft1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraft1.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Borrowing details")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBOverdraft1 {
     @JsonProperty("Notes")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftFeeChargeCap1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftFeeChargeCap1.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBOverdraftFeeChargeCap1 {
   @JsonProperty("FeeType")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftFeesChargeDetails1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftFeesChargeDetails1.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Details about the fees/charges")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBOverdraftFeesChargeDetails1 {
 

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftFeesCharges1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftFeesCharges1.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Overdraft fees and charges details")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBOverdraftFeesCharges1 {
   @JsonProperty("OverdraftFeeChargeCap")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftTierBand1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftTierBand1.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Provides overdraft details for a specific tier or band")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBOverdraftTierBand1 {
   @JsonProperty("Identification")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftTierbandSet1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBOverdraftTierbandSet1.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Tier band set details")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBOverdraftTierbandSet1 {
 

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPCAData1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPCAData1.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 /**
  * OBPCAData1
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBPCAData1   {
   @JsonProperty("ProductDetails")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPCAProductDetails1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPCAProductDetails1.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * OBPCAProductDetails1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBPCAProductDetails1 {
 

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBParty1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBParty1.java
@@ -31,7 +31,7 @@ import java.util.Objects;
  * OBParty1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBParty1 {
     @JsonProperty("PartyId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBParty2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBParty2.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 /**
  * OBParty2
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBParty2 {
     @JsonProperty("PartyId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBParty2Address.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBParty2Address.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  * Postal address of a party.
  */
 @ApiModel(description = "Postal address of a party.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBParty2Address {
     @JsonProperty("AddressType")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPartyRelationships1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPartyRelationships1.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  * The Party&#39;s relationships with other resources.
  */
 @ApiModel(description = "The Party's relationships with other resources.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBPartyRelationships1 {
   @JsonProperty("Account")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPartyRelationships1Account.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPartyRelationships1Account.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Relationship to the Account resource.
  */
 @ApiModel(description = "Relationship to the Account resource.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBPartyRelationships1Account   {
   @JsonProperty("Related")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPostalAddress8.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBPostalAddress8.java
@@ -34,7 +34,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Postal address of a party.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBPostalAddress8 {
     @JsonProperty("AddressType")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBProduct1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBProduct1.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Product
  */
 @ApiModel(description = "Product")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-16T08:37:28.078Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBProduct1 {
   @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBProduct2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBProduct2.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * OBProduct2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBProduct2   {
   @JsonProperty("ProductName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount1.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * AccountGETResponse
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-16T08:37:28.078Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadAccount1 {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount2.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * OBReadAccount2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadAccount2   {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount2Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount2Data.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * OBReadAccount2Data
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadAccount2Data   {
   @JsonProperty("Account")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount3.java
@@ -40,7 +40,7 @@ import java.util.Objects;
 /**
  * OBReadAccount3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadAccount3 {
     @JsonProperty("Data")
     private OBReadAccount3Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount3Data.java
@@ -39,7 +39,7 @@ import java.util.Objects;
 /**
  * OBReadAccount3Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadAccount3Data {
     @JsonProperty("Account")
     private List<OBAccount3> account = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount4.java
@@ -40,7 +40,7 @@ import java.util.Objects;
 /**
  * OBReadAccount4
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T15:59:01.633+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadAccount4 {
     @JsonProperty("Data")
     private OBReadAccount4Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount4Data.java
@@ -39,7 +39,7 @@ import java.util.Objects;
 /**
  * OBReadAccount4Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T15:59:01.633+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadAccount4Data {
     @JsonProperty("Account")
     private List<OBAccount4> account = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount5.java
@@ -40,7 +40,7 @@ import java.util.Objects;
 /**
  * OBReadAccount5
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T10:29:01.751+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadAccount5 {
     @JsonProperty("Data")
     private OBReadAccount5Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount5Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount5Data.java
@@ -39,7 +39,7 @@ import java.util.Objects;
 /**
  * OBReadAccount5Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T10:29:01.751+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadAccount5Data {
     @JsonProperty("Account")
     private List<OBAccount6> account = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount6.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount6.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * OBReadAccount6
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadAccount6 {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount6Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadAccount6Data.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * OBReadAccount6Data
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadAccount6Data   {
   @JsonProperty("Account")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * OBReadBalance1
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadBalance1 {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1Data.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 /**
  * OBReadBalance1Data
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadBalance1Data {
   @JsonProperty("Balance")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataAmount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataAmount.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Amount of money of the cash balance.
  */
 @ApiModel(description = "Amount of money of the cash balance.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadBalance1DataAmount {
     @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataAmount1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataAmount1.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Amount of money of the credit line.
  */
 @ApiModel(description = "Amount of money of the credit line.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadBalance1DataAmount1 {
     @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataBalance.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataBalance.java
@@ -31,7 +31,7 @@ import java.util.Objects;
  * Set of elements used to define the balance details.
  */
 @ApiModel(description = "Set of elements used to define the balance details.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadBalance1DataBalance {
   @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataCreditLine.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBalance1DataCreditLine.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * Set of elements used to provide details on the credit line.
  */
 @ApiModel(description = "Set of elements used to provide details on the credit line.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadBalance1DataCreditLine {
   @JsonProperty("Included")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary1.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * BeneficiariesGETResponse
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-16T08:37:28.078Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadBeneficiary1 {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary2.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * OBReadBeneficiary2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadBeneficiary2   {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary2Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary2Data.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * OBReadBeneficiary2Data
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadBeneficiary2Data   {
   @JsonProperty("Beneficiary")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary3.java
@@ -40,7 +40,7 @@ import java.util.Objects;
 /**
  * OBReadBeneficiary3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadBeneficiary3 {
     @JsonProperty("Data")
     private OBReadBeneficiary3Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary3Data.java
@@ -39,7 +39,7 @@ import java.util.Objects;
 /**
  * OBReadBeneficiary3Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadBeneficiary3Data {
     @JsonProperty("Beneficiary")
     private List<OBBeneficiary3> beneficiary = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary4.java
@@ -40,7 +40,7 @@ import java.util.Objects;
 /**
  * OBReadBeneficiary4
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T10:29:01.751+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadBeneficiary4 {
     @JsonProperty("Data")
     private OBReadBeneficiary4Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary4Data.java
@@ -39,7 +39,7 @@ import java.util.Objects;
 /**
  * OBReadBeneficiary4Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T10:29:01.751+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadBeneficiary4Data {
     @JsonProperty("Beneficiary")
     private List<OBBeneficiary4> beneficiary = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary5.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * OBReadBeneficiary5
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadBeneficiary5 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary5Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadBeneficiary5Data.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * OBReadBeneficiary5Data
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadBeneficiary5Data {
   @JsonProperty("Beneficiary")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsent1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsent1.java
@@ -38,7 +38,7 @@ import java.util.Objects;
 /**
  * OBReadConsent1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2021-05-05T09:20:17.613+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadConsent1 {
     @JsonProperty("Data")
     private OBReadData1 data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsent1Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsent1Data.java
@@ -41,7 +41,7 @@ import java.util.Objects;
 /**
  * OBReadConsent1Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T15:59:01.633+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadConsent1Data {
     @JsonProperty("Permissions")
     private List<PermissionsEnum> permissions = new ArrayList<PermissionsEnum>();

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsentResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsentResponse1.java
@@ -40,7 +40,7 @@ import java.util.Objects;
 /**
  * OBReadConsentResponse1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2021-05-05T09:20:17.613+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadConsentResponse1 {
     @JsonProperty("Data")
     private OBReadConsentResponse1Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsentResponse1Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadConsentResponse1Data.java
@@ -43,7 +43,7 @@ import java.util.Objects;
 /**
  * OBReadConsentResponse1Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2021-05-05T09:20:17.613+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadConsentResponse1Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadData1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadData1.java
@@ -31,7 +31,7 @@ import java.util.Objects;
  * OBReadData1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadData1   {
   @JsonProperty("Permissions")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataAccount1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataAccount1.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Data
  */
 @ApiModel(description = "Data")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-16T08:37:28.078Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadDataAccount1 {
   @JsonProperty("Account")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataBeneficiary1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataBeneficiary1.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Data
  */
 @ApiModel(description = "Data")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-16T08:37:28.078Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadDataBeneficiary1 {
   @JsonProperty("Beneficiary")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataDirectDebit1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataDirectDebit1.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Data
  */
 @ApiModel(description = "Data")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-16T08:37:28.078Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadDataDirectDebit1 {
   @JsonProperty("DirectDebit")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataProduct1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataProduct1.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Data
  */
 @ApiModel(description = "Data")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-16T08:37:28.078Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadDataProduct1 {
   @JsonProperty("Product")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataResponse1.java
@@ -36,7 +36,7 @@ import java.util.Objects;
  * Account Request Response
  */
 @ApiModel(description = "Account Request Response")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-16T08:37:28.078Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadDataResponse1 {
   @JsonProperty("AccountRequestId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataStandingOrder1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataStandingOrder1.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Data
  */
 @ApiModel(description = "Data")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-16T08:37:28.078Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadDataStandingOrder1 {
   @JsonProperty("StandingOrder")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataStatement2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataStatement2.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * OBReadDataStatement2
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadDataStatement2 {
     @JsonProperty("Statement")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataTransaction1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataTransaction1.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * Data
  */
 @ApiModel(description = "Data")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-16T08:37:28.078Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadDataTransaction1 {
   @JsonProperty("Transaction")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataTransaction5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataTransaction5.java
@@ -39,7 +39,7 @@ import java.util.Objects;
 /**
  * OBReadDataTransaction5
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T15:59:01.633+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadDataTransaction5 {
     @JsonProperty("Transaction")
     private List<OBTransaction5> transaction = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataTransaction6.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDataTransaction6.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * OBReadDataTransaction6
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadDataTransaction6 {
     @JsonProperty("Transaction")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit1.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * OBReadDirectDebit1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadDirectDebit1   {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit1Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit1Data.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * OBReadDirectDebit1Data
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadDirectDebit1Data   {
   @JsonProperty("DirectDebit")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit1DataDirectDebit.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit1DataDirectDebit.java
@@ -43,7 +43,7 @@ import java.util.Objects;
  * Account to or from which a cash entry is made.
  */
 @ApiModel(description = "Account to or from which a cash entry is made.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T15:59:01.633+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadDirectDebit1DataDirectDebit {
     @JsonProperty("AccountId")
     private String accountId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit1DataPreviousPaymentAmount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit1DataPreviousPaymentAmount.java
@@ -40,7 +40,7 @@ import java.util.Objects;
  * The amount of the most recent direct debit collection.
  */
 @ApiModel(description = "The amount of the most recent direct debit collection.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T15:59:01.633+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadDirectDebit1DataPreviousPaymentAmount {
     @JsonProperty("Amount")
     private String amount = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit2.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * OBReadDirectDebit2
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadDirectDebit2 {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit2Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit2Data.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * OBReadDirectDebit2Data
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadDirectDebit2Data {
     @JsonProperty("DirectDebit")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit2DataDirectDebit.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadDirectDebit2DataDirectDebit.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * Account to or from which a cash entry is made.
  */
 @ApiModel(description = "Account to or from which a cash entry is made.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadDirectDebit2DataDirectDebit {
     @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * OBReadOffer1
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadOffer1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1Data.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * OBReadOffer1Data
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadOffer1Data {
     @JsonProperty("Offer")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1DataAmount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1DataAmount.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Amount of money associated with the offer type.
  */
 @ApiModel(description = "Amount of money associated with the offer type.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadOffer1DataAmount {
     @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1DataFee.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1DataFee.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Fee associated with the offer type.
  */
 @ApiModel(description = "Fee associated with the offer type.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadOffer1DataFee {
     @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1DataOffer.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadOffer1DataOffer.java
@@ -30,7 +30,7 @@ import java.util.Objects;
 /**
  * OBReadOffer1DataOffer
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadOffer1DataOffer {
     @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty1.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * OBReadParty1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadParty1   {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty1Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty1Data.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  * OBReadParty1Data
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadParty1Data   {
   @JsonProperty("Party")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty1DataParty.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty1DataParty.java
@@ -42,7 +42,7 @@ import java.util.Objects;
 /**
  * OBReadParty1DataParty
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T15:59:01.633+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadParty1DataParty {
     @JsonProperty("PartyId")
     private String partyId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty2.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * OBReadParty2
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadParty2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty2Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty2Data.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 /**
  * OBReadParty2Data
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadParty2Data {
     @JsonProperty("Party")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty3.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * OBReadParty3
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadParty3 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadParty3Data.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * OBReadParty3Data
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadParty3Data {
     @JsonProperty("Party")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct1.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * ProductGETResponse
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-16T08:37:28.078Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadProduct1 {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * Product details of Other Product which is not avaiable in the standard list
  */
 @ApiModel(description = "Product details of Other Product which is not avaiable in the standard list")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2Data.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Aligning with the read write specs structure.
  */
 @ApiModel(description = "Aligning with the read write specs structure.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2Data   {
   @JsonProperty("Product")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductType.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductType.java
@@ -31,7 +31,7 @@ import java.util.Objects;
  * Other product type details associated with the account.
  */
 @ApiModel(description = "Other product type details associated with the account.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductType {
     @JsonProperty("Name")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeCreditInterest.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeCreditInterest.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Details about the interest that may be payable to the Account holders
  */
 @ApiModel(description = "Details about the interest that may be payable to the Account holders")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeCreditInterest {
     @JsonProperty("TierBandSet")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other interest rate types which are not available in the standard code list
  */
 @ApiModel(description = "Other interest rate types which are not available in the standard code list")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeCreditInterestOtherBankInterestType {
     @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeCreditInterestTierBand.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeCreditInterestTierBand.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * Tier Band Details
  */
 @ApiModel(description = "Tier Band Details")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeCreditInterestTierBand {
     @JsonProperty("Identification")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  * The group of tiers or bands for which credit interest can be applied.
  */
 @ApiModel(description = "The group of tiers or bands for which credit interest can be applied.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeCreditInterestTierBandSet {
     /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeFeeApplicableRange.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeFeeApplicableRange.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  * Range or amounts or rates for which the fee/charge applies
  */
 @ApiModel(description = "Range or amounts or rates for which the fee/charge applies")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeFeeApplicableRange {
   @JsonProperty("MinimumAmount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeFeeChargeCap.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeFeeChargeCap.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * Details about any caps (maximum charges) that apply to a particular or group of fee/charge
  */
 @ApiModel(description = "Details about any caps (maximum charges) that apply to a particular or group of fee/charge")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeFeeChargeCap {
   /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeFeeChargeDetail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeFeeChargeDetail.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Other fees/charges details
  */
 @ApiModel(description = "Other fees/charges details")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeFeeChargeDetail   {
   @JsonProperty("FeeCategory")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterest.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterest.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Details about the interest that may be payable to the SME Loan holders
  */
 @ApiModel(description = "Details about the interest that may be payable to the SME Loan holders")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeLoanInterest {
     @JsonProperty("Notes")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * Details about any caps (minimum/maximum charges) that apply to a particular fee/charge
  */
 @ApiModel(description = "Details about any caps (minimum/maximum charges) that apply to a particular fee/charge")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeCap {
     /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Other fees/charges details
  */
 @ApiModel(description = "Other fees/charges details")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeeChargeDetail {
     @JsonProperty("FeeType")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Contains details of fees and charges which are not associated with either LoanRepayment or features/benefits
  */
 @ApiModel(description = "Contains details of fees and charges which are not associated with either LoanRepayment or features/benefits")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestFeesCharges {
     @JsonProperty("LoanInterestFeeChargeDetail")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * Tier Band Details
  */
 @ApiModel(description = "Tier Band Details")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBand {
   @JsonProperty("Identification")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  * The group of tiers or bands for which debit interest can be applied.
  */
 @ApiModel(description = "The group of tiers or bands for which debit interest can be applied.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeLoanInterestLoanInterestTierBandSet   {
   /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestOtherFeeType.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestOtherFeeType.java
@@ -41,7 +41,7 @@ import java.util.Objects;
  * Other fee type code which is not available in the standard code set
  */
 @ApiModel(description = "Other fee type code which is not available in the standard code set")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2021-05-05T09:20:17.613+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadProduct2DataOtherProductTypeLoanInterestOtherFeeType {
     @JsonProperty("Code")
     private String code = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other loan interest rate types which are not available in the standard code list
  */
 @ApiModel(description = "Other loan interest rate types which are not available in the standard code list")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeLoanInterestOtherLoanProviderInterestRateType {
     @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOtherFeesCharges.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOtherFeesCharges.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  * Contains details of fees and charges which are not associated with either Overdraft or features/benefits
  */
 @ApiModel(description = "Contains details of fees and charges which are not associated with either Overdraft or features/benefits")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeOtherFeesCharges {
     /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOtherTariffType.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOtherTariffType.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other tariff type which is not in the standard list.
  */
 @ApiModel(description = "Other tariff type which is not in the standard list.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeOtherTariffType {
     @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraft.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraft.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Borrowing details
  */
 @ApiModel(description = "Borrowing details")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeOverdraft {
     @JsonProperty("Notes")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other fee type code which is not available in the standard code set
  */
 @ApiModel(description = "Other fee type code which is not available in the standard code set")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeOverdraftOtherFeeType {
     @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.
  */
 @ApiModel(description = "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeCap {
   /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Details about the fees/charges
  */
 @ApiModel(description = "Details about the fees/charges")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeeChargeDetail {
   @JsonProperty("FeeType")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Overdraft fees and charges
  */
 @ApiModel(description = "Overdraft fees and charges")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges {
     @JsonProperty("OverdraftFeeChargeCap")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Overdraft fees and charges details
  */
 @ApiModel(description = "Overdraft fees and charges details")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeOverdraftOverdraftFeesCharges1 {
   @JsonProperty("OverdraftFeeChargeCap")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * Provides overdraft details for a specific tier or band
  */
 @ApiModel(description = "Provides overdraft details for a specific tier or band")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBand {
     @JsonProperty("Identification")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * Tier band set details
  */
 @ApiModel(description = "Tier band set details")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeOverdraftOverdraftTierBandSet {
   /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeProductDetails.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeProductDetails.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 /**
  * OBReadProduct2DataOtherProductTypeProductDetails
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeProductDetails {
     /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepayment.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepayment.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Repayment details of the Loan product
  */
 @ApiModel(description = "Repayment details of the Loan product")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeRepayment {
     /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other amount type which is not in the standard code list
  */
 @ApiModel(description = "Other amount type which is not in the standard code list")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeRepaymentOtherAmountType {
     @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other repayment frequency which is not in the standard code list
  */
 @ApiModel(description = "Other repayment frequency which is not in the standard code list")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentFrequency {
   @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other repayment type which is not in the standard code list
  */
 @ApiModel(description = "Other repayment type which is not in the standard code list")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeRepaymentOtherRepaymentType   {
   @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Applicable fee/charges for repayment such as prepayment, full early repayment or non repayment.
  */
 @ApiModel(description = "Applicable fee/charges for repayment such as prepayment, full early repayment or non repayment.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeCharges {
     @JsonProperty("RepaymentFeeChargeDetail")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * RepaymentFeeChargeCap sets daily, weekly, monthly, yearly limits on the fees that are charged
  */
 @ApiModel(description = "RepaymentFeeChargeCap sets daily, weekly, monthly, yearly limits on the fees that are charged")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeCap {
     /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Details about specific fees/charges that are applied for repayment
  */
 @ApiModel(description = "Details about specific fees/charges that are applied for repayment")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeRepaymentRepaymentFeeChargesRepaymentFeeChargeDetail {
     @JsonProperty("FeeType")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Details of capital repayment holiday if any
  */
 @ApiModel(description = "Details of capital repayment holiday if any")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataOtherProductTypeRepaymentRepaymentHoliday {
   @JsonProperty("MaxHolidayLength")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProduct.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataProduct.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Product details associated with the Account
  */
 @ApiModel(description = "Product details associated with the Account")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadProduct2DataProduct {
     @JsonProperty("ProductName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadRequest1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadRequest1.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Allows setup of an account access request
  */
 @ApiModel(description = "Allows setup of an account access request")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-16T08:37:28.078Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadRequest1 {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadResponse1.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * AccountRequestPOSTResponse
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-16T08:37:28.078Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadResponse1 {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment1.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * OBReadScheduledPayment1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadScheduledPayment1   {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment1Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment1Data.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * OBReadScheduledPayment1Data
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadScheduledPayment1Data   {
   @JsonProperty("ScheduledPayment")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment2.java
@@ -40,7 +40,7 @@ import java.util.Objects;
 /**
  * OBReadScheduledPayment2
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadScheduledPayment2 {
     @JsonProperty("Data")
     private OBReadScheduledPayment2Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment2Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment2Data.java
@@ -39,7 +39,7 @@ import java.util.Objects;
 /**
  * OBReadScheduledPayment2Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadScheduledPayment2Data {
     @JsonProperty("ScheduledPayment")
     private List<OBScheduledPayment2> scheduledPayment = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment3.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * OBReadScheduledPayment3
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadScheduledPayment3 {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadScheduledPayment3Data.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * OBReadScheduledPayment3Data
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadScheduledPayment3Data {
     @JsonProperty("ScheduledPayment")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder1.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * StandingOrdersGETResponse
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-16T08:37:28.078Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadStandingOrder1 {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder2.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * OBReadStandingOrder2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadStandingOrder2   {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder2Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder2Data.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * OBReadStandingOrder2Data
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadStandingOrder2Data   {
   @JsonProperty("StandingOrder")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder3.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * OBReadStandingOrder3
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadStandingOrder3   {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder3Data.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * OBReadStandingOrder3Data
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadStandingOrder3Data   {
   @JsonProperty("StandingOrder")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder4.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * OBReadStandingOrder4
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:14:51.272Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadStandingOrder4   {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder4Data.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * OBReadStandingOrder4Data
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:14:51.272Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadStandingOrder4Data   {
   @JsonProperty("StandingOrder")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder5.java
@@ -40,7 +40,7 @@ import java.util.Objects;
 /**
  * OBReadStandingOrder5
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadStandingOrder5 {
     @JsonProperty("Data")
     private OBReadStandingOrder5Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder5Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder5Data.java
@@ -39,7 +39,7 @@ import java.util.Objects;
 /**
  * OBReadStandingOrder5Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadStandingOrder5Data {
     @JsonProperty("StandingOrder")
     private List<OBStandingOrder5> standingOrder = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder6.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder6.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * OBReadStandingOrder6
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadStandingOrder6 {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder6Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStandingOrder6Data.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * OBReadStandingOrder6Data
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadStandingOrder6Data   {
   @JsonProperty("StandingOrder")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStatement1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStatement1.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * OBReadStatement1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadStatement1   {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStatement1Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStatement1Data.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * OBReadStatement1Data
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadStatement1Data   {
   @JsonProperty("Statement")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStatement2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStatement2.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * OBReadStatement2
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadStatement2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStatement2Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadStatement2Data.java
@@ -39,7 +39,7 @@ import java.util.Objects;
 /**
  * OBReadStatement2Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadStatement2Data {
     @JsonProperty("Statement")
     private List<OBStatement2> statement = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction1.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * AccountTransactionsGETResponse
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-16T08:37:28.078Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadTransaction1 {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction2.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * OBReadTransaction2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadTransaction2   {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction2Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction2Data.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * OBReadTransaction2Data
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadTransaction2Data   {
   @JsonProperty("Transaction")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction3.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * OBReadTransaction3
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadTransaction3   {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction3Data.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * OBReadTransaction3Data
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadTransaction3Data   {
   @JsonProperty("Transaction")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction4.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * OBReadTransaction4
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:14:51.272Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadTransaction4   {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction4Data.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * OBReadTransaction4Data
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:14:51.272Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBReadTransaction4Data   {
   @JsonProperty("Transaction")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction5.java
@@ -40,7 +40,7 @@ import java.util.Objects;
 /**
  * OBReadTransaction5
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadTransaction5 {
     @JsonProperty("Data")
     private OBReadTransaction5Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction5Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction5Data.java
@@ -39,7 +39,7 @@ import java.util.Objects;
 /**
  * OBReadTransaction5Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBReadTransaction5Data {
     @JsonProperty("Transaction")
     private List<OBTransaction5> transaction = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction6.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBReadTransaction6.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * OBReadTransaction6
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBReadTransaction6   {
   @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRelationship1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRelationship1.java
@@ -40,7 +40,7 @@ import java.util.Objects;
  * Relationship to the Account resource.
  */
 @ApiModel(description = "Relationship to the Account resource.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBRelationship1 {
     @JsonProperty("Related")
     private String related = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepayment1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepayment1.java
@@ -41,7 +41,7 @@ import java.util.Objects;
  * Repayment details of the Loan product
  */
 @ApiModel(description = "Repayment details of the Loan product")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBRepayment1 {
     @JsonProperty("RepaymentType")
     private OBRepaymentType1Code repaymentType = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepaymentFeeChargeCap1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepaymentFeeChargeCap1.java
@@ -43,7 +43,7 @@ import java.util.Objects;
  * RepaymentFeeChargeCap sets daily, weekly, monthly, yearly limits on the fees that are charged
  */
 @ApiModel(description = "RepaymentFeeChargeCap sets daily, weekly, monthly, yearly limits on the fees that are charged")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBRepaymentFeeChargeCap1 {
     @JsonProperty("FeeType")
     private List<OBFeeType1Code> feeType = new ArrayList<OBFeeType1Code>();

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepaymentFeeChargeDetail1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepaymentFeeChargeDetail1.java
@@ -43,7 +43,7 @@ import java.util.Objects;
  * Details about specific fees/charges that are applied for repayment
  */
 @ApiModel(description = "Details about specific fees/charges that are applied for repayment")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBRepaymentFeeChargeDetail1 {
     @JsonProperty("FeeType")
     private OBFeeType1Code feeType = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepaymentFeeCharges1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepaymentFeeCharges1.java
@@ -43,7 +43,7 @@ import java.util.Objects;
  * Applicable fee/charges for repayment such as prepayment, full early repayment or non repayment.
  */
 @ApiModel(description = "Applicable fee/charges for repayment such as prepayment, full early repayment or non repayment.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBRepaymentFeeCharges1 {
     @JsonProperty("RepaymentFeeChargeDetail")
     private List<OBRepaymentFeeChargeDetail1> repaymentFeeChargeDetail = new ArrayList<OBRepaymentFeeChargeDetail1>();

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepaymentHoliday1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRepaymentHoliday1.java
@@ -41,7 +41,7 @@ import java.util.Objects;
  * Details of capital repayment holiday if any
  */
 @ApiModel(description = "Details of capital repayment holiday if any")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBRepaymentHoliday1 {
     @JsonProperty("MaxHolidayLength")
     private Integer maxHolidayLength = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRisk2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBRisk2.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @JsonDeserialize(using = OBRisk2Deserializer.class)
 @JsonSerialize(using = OBRisk2Serializer.class)

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment1.java
@@ -31,7 +31,7 @@ import java.util.Objects;
  * OBScheduledPayment1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBScheduledPayment1   {
   @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment2.java
@@ -41,7 +41,7 @@ import java.util.Objects;
 /**
  * OBScheduledPayment2
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBScheduledPayment2 {
     @JsonProperty("AccountId")
     private String accountId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment2Basic.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment2Basic.java
@@ -41,7 +41,7 @@ import java.util.Objects;
 /**
  * OBScheduledPayment2Basic
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBScheduledPayment2Basic {
     @JsonProperty("AccountId")
     private String accountId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment2Detail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment2Detail.java
@@ -41,7 +41,7 @@ import java.util.Objects;
 /**
  * OBScheduledPayment2Detail
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBScheduledPayment2Detail {
     @JsonProperty("AccountId")
     private String accountId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment3.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * OBScheduledPayment3
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBScheduledPayment3 {
     @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment3Basic.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment3Basic.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * OBScheduledPayment3Basic
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBScheduledPayment3Basic {
     @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment3Detail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBScheduledPayment3Detail.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * OBScheduledPayment3Detail
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBScheduledPayment3Detail {
   @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder1.java
@@ -36,7 +36,7 @@ import java.util.Objects;
  * Standing Order
  */
 @ApiModel(description = "Standing Order")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-16T08:37:28.078Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBStandingOrder1 {
   @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder2.java
@@ -38,7 +38,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Account to or from which a cash entry is made.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBStandingOrder2   {
   @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder3.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  * OBStandingOrder3
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBStandingOrder3   {
   @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder4.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * OBStandingOrder4
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:14:51.272Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBStandingOrder4   {
   @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder4Basic.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder4Basic.java
@@ -41,7 +41,7 @@ import java.util.Objects;
 /**
  * OBStandingOrder4Basic
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T15:59:01.633+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBStandingOrder4Basic {
     @JsonProperty("AccountId")
     private String accountId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder4Detail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder4Detail.java
@@ -41,7 +41,7 @@ import java.util.Objects;
 /**
  * OBStandingOrder4Detail
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T15:59:01.633+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBStandingOrder4Detail {
     @JsonProperty("AccountId")
     private String accountId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder5.java
@@ -43,7 +43,7 @@ import java.util.Objects;
 /**
  * OBStandingOrder5
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBStandingOrder5 {
     @JsonProperty("AccountId")
     private String accountId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder5Basic.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder5Basic.java
@@ -43,7 +43,7 @@ import java.util.Objects;
 /**
  * OBStandingOrder5Basic
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBStandingOrder5Basic {
     @JsonProperty("AccountId")
     private String accountId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder5Detail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder5Detail.java
@@ -43,7 +43,7 @@ import java.util.Objects;
 /**
  * OBStandingOrder5Detail
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBStandingOrder5Detail {
     @JsonProperty("AccountId")
     private String accountId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 /**
  * OBStandingOrder6
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBStandingOrder6 {
     @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6Basic.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6Basic.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 /**
  * OBStandingOrder6Basic
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBStandingOrder6Basic {
   @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6Detail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6Detail.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 /**
  * OBStandingOrder6Detail
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBStandingOrder6Detail {
     @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement1.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Provides further details on a statement resource.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBStatement1 {
     @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2.java
@@ -31,7 +31,7 @@ import java.util.Objects;
  * Provides further details on a statement resource.
  */
 @ApiModel(description = "Provides further details on a statement resource.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBStatement2 {
     @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2Basic.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2Basic.java
@@ -31,7 +31,7 @@ import java.util.Objects;
  * Provides further details on a statement resource.
  */
 @ApiModel(description = "Provides further details on a statement resource.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBStatement2Basic   {
   @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2Detail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2Detail.java
@@ -31,7 +31,7 @@ import java.util.Objects;
  * Provides further details on a statement resource.
  */
 @ApiModel(description = "Provides further details on a statement resource.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBStatement2Detail {
   @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementAmount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementAmount.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Set of elements used to provide details of a generic amount for the statement resource.
  */
 @ApiModel(description = "Set of elements used to provide details of a generic amount for the statement resource.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBStatement2StatementAmount {
   @JsonProperty("CreditDebitIndicator")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementBenefit.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementBenefit.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Set of elements used to provide details of a benefit or reward amount for the statement resource.
  */
 @ApiModel(description = "Set of elements used to provide details of a benefit or reward amount for the statement resource.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBStatement2StatementBenefit {
     @JsonProperty("Type")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementDateTime.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementDateTime.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Set of elements used to provide details of a generic date time for the statement resource.
  */
 @ApiModel(description = "Set of elements used to provide details of a generic date time for the statement resource.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBStatement2StatementDateTime {
     @JsonProperty("DateTime")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementFee.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementFee.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * Set of elements used to provide details of a fee for the statement resource.
  */
 @ApiModel(description = "Set of elements used to provide details of a fee for the statement resource.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBStatement2StatementFee {
     @JsonProperty("Description")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementInterest.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementInterest.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * Set of elements used to provide details of a generic interest amount related to the statement resource.
  */
 @ApiModel(description = "Set of elements used to provide details of a generic interest amount related to the statement resource.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBStatement2StatementInterest {
   @JsonProperty("Description")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementRate.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementRate.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Set of elements used to provide details of a generic rate related to the statement resource.
  */
 @ApiModel(description = "Set of elements used to provide details of a generic rate related to the statement resource.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBStatement2StatementRate {
   @JsonProperty("Rate")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementValue.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatement2StatementValue.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Set of elements used to provide details of a generic number value related to the statement resource.
  */
 @ApiModel(description = "Set of elements used to provide details of a generic number value related to the statement resource.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBStatement2StatementValue {
   @JsonProperty("Value")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementAmount1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementAmount1.java
@@ -31,7 +31,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Set of elements used to provide details of a generic amount for the statement resource.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBStatementAmount1   {
 

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementBenefit1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementBenefit1.java
@@ -31,7 +31,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Set of elements used to provide details of a benefit or reward amount for the statement resource.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBStatementBenefit1   {
   @JsonProperty("Type")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementDateTime1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementDateTime1.java
@@ -31,7 +31,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Set of elements used to provide details of a generic date time for the statement resource.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBStatementDateTime1   {
   @JsonProperty("DateTime")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementFee1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementFee1.java
@@ -31,7 +31,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Set of elements used to provide details of a fee for the statement resource.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBStatementFee1   {
 

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementFee2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementFee2.java
@@ -45,7 +45,7 @@ import java.util.Objects;
  * Set of elements used to provide details of a fee for the statement resource.
  */
 @ApiModel(description = "Set of elements used to provide details of a fee for the statement resource.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBStatementFee2 {
     @JsonProperty("Description")
     private String description = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementInterest1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementInterest1.java
@@ -31,7 +31,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Set of elements used to provide details of a generic interest amount related to the statement resource.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBStatementInterest1   {
 

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementInterest2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementInterest2.java
@@ -45,7 +45,7 @@ import java.util.Objects;
  * Set of elements used to provide details of a generic interest amount related to the statement resource.
  */
 @ApiModel(description = "Set of elements used to provide details of a generic interest amount related to the statement resource.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBStatementInterest2 {
     @JsonProperty("Description")
     private String description = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementRate1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementRate1.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Set of elements used to provide details of a generic rate related to the statement resource.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBStatementRate1   {
   @JsonProperty("Rate")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementValue1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBStatementValue1.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Set of elements used to provide details of a generic number value related to the statement resource.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBStatementValue1   {
   @JsonProperty("Value")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTierBand1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTierBand1.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Tier Band Details")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBTierBand1 {
   @JsonProperty("Identification")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTierBandSet1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTierBandSet1.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "The group of tiers or bands for which credit interest can be applied.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBTierBandSet1 {
 

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction1.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 /**
  * Data3Transaction
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-16T08:37:28.078Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBTransaction1 {
   @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction2.java
@@ -39,7 +39,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Provides further details on an entry in the report.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBTransaction2   {
   @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction3.java
@@ -35,7 +35,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Provides further details on an entry in the report.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBTransaction3   {
   @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction3ProprietaryBankTransactionCode.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction3ProprietaryBankTransactionCode.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Set of elements to fully identify a proprietary bank transaction code.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBTransaction3ProprietaryBankTransactionCode   {
   @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction4.java
@@ -36,7 +36,7 @@ import java.util.Objects;
  */
 @ApiModel(description = "Provides further details on an entry in the report.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:14:51.272Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBTransaction4   {
   @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction5.java
@@ -49,7 +49,7 @@ import java.util.Objects;
  * Provides further details on an entry in the report.
  */
 @ApiModel(description = "Provides further details on an entry in the report.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBTransaction5 {
     @JsonProperty("AccountId")
     private String accountId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction5Basic.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction5Basic.java
@@ -48,7 +48,7 @@ import java.util.Objects;
  * Provides further details on an entry in the report.
  */
 @ApiModel(description = "Provides further details on an entry in the report.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBTransaction5Basic {
     @JsonProperty("AccountId")
     private String accountId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction5Detail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction5Detail.java
@@ -49,7 +49,7 @@ import java.util.Objects;
  * Provides further details on an entry in the report.
  */
 @ApiModel(description = "Provides further details on an entry in the report.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBTransaction5Detail {
     @JsonProperty("AccountId")
     private String accountId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction5ProprietaryBankTransactionCode.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction5ProprietaryBankTransactionCode.java
@@ -40,7 +40,7 @@ import java.util.Objects;
  * Set of elements to fully identify a proprietary bank transaction code.
  */
 @ApiModel(description = "Set of elements to fully identify a proprietary bank transaction code.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:27:41.089+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBTransaction5ProprietaryBankTransactionCode {
     @JsonProperty("Code")
     private String code = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6.java
@@ -30,7 +30,7 @@ import java.util.*;
  * Provides further details on an entry in the report.
  */
 @ApiModel(description = "Provides further details on an entry in the report.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBTransaction6 {
   @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6Basic.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6Basic.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  * Provides further details on an entry in the report.
  */
 @ApiModel(description = "Provides further details on an entry in the report.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBTransaction6Basic {
   @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6Detail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6Detail.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  * Provides further details on an entry in the report.
  */
 @ApiModel(description = "Provides further details on an entry in the report.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBTransaction6Detail {
   @JsonProperty("AccountId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionCardInstrument1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionCardInstrument1.java
@@ -29,7 +29,7 @@ import java.util.Objects;
  * Set of elements to describe the card instrument used in the transaction.
  */
 @ApiModel(description = "Set of elements to describe the card instrument used in the transaction.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBTransactionCardInstrument1 {
     /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionCashBalance.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionCashBalance.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Set of elements used to define the balance as a numerical representation of the net increases and decreases in an account after a transaction entry is applied to the account.
  */
 @ApiModel(description = "Set of elements used to define the balance as a numerical representation of the net increases and decreases in an account after a transaction entry is applied to the account.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBTransactionCashBalance {
     @JsonProperty("CreditDebitIndicator")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionCashBalanceAmount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OBTransactionCashBalanceAmount.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Amount of money of the cash balance after a transaction entry is applied to the account..
  */
 @ApiModel(description = "Amount of money of the cash balance after a transaction entry is applied to the account..")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBTransactionCashBalanceAmount {
     @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherApplicationFrequency.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherApplicationFrequency.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other application frequencies that are not available in the standard code list
  */
 @ApiModel(description = "Other application frequencies that are not available in the standard code list")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OtherApplicationFrequency   {
   @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherApplicationFrequency1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherApplicationFrequency1.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other application frequencies not covered in the standard code list
  */
 @ApiModel(description = "Other application frequencies not covered in the standard code list")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OtherApplicationFrequency1 {
   @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherBankInterestType.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherBankInterestType.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other interest rate types which are not available in the standard code list
  */
 @ApiModel(description = "Other interest rate types which are not available in the standard code list")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OtherBankInterestType {
     @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherCalculationFrequency.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherCalculationFrequency.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other calculation frequency which is not available in the standard code set.
  */
 @ApiModel(description = "Other calculation frequency which is not available in the standard code set.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OtherCalculationFrequency {
     @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherCalculationFrequency1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherCalculationFrequency1.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other calculation frequency which is not available in standard code set.
  */
 @ApiModel(description = "Other calculation frequency which is not available in standard code set.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OtherCalculationFrequency1 {
   @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeCategoryType.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeCategoryType.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * OtherFeeCategoryType
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OtherFeeCategoryType {
   @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeRateType.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeRateType.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other fee rate type code which is not available in the standard code set
  */
 @ApiModel(description = "Other fee rate type code which is not available in the standard code set")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OtherFeeRateType {
   @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeRateType1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeRateType1.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other fee rate type which is not available in the standard code set
  */
 @ApiModel(description = "Other fee rate type which is not available in the standard code set")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OtherFeeRateType1 {
   @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeType.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeType.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other Fee type which is not available in the standard code set
  */
 @ApiModel(description = "Other Fee type which is not available in the standard code set")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OtherFeeType {
     @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeType1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeeType1.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Other Fee/charge type which is not available in the standard code set
  */
 @ApiModel(description = "Other Fee/charge type which is not available in the standard code set")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OtherFeeType1 {
   @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeesCharges.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeesCharges.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Contains details of fees and charges which are not associated with either borrowing or features/benefits
  */
 @ApiModel(description = "Contains details of fees and charges which are not associated with either borrowing or features/benefits")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OtherFeesCharges {
   @JsonProperty("FeeChargeDetail")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeesChargesFeeChargeCap.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeesChargesFeeChargeCap.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * Details about any caps (maximum charges) that apply to a particular fee/charge
  */
 @ApiModel(description = "Details about any caps (maximum charges) that apply to a particular fee/charge")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OtherFeesChargesFeeChargeCap {
   /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeesChargesFeeChargeDetail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherFeesChargesFeeChargeDetail.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  * Other fees/charges details
  */
 @ApiModel(description = "Other fees/charges details")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OtherFeesChargesFeeChargeDetail {
   /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherTariffType.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OtherTariffType.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other tariff type which is not in the standard list.
  */
 @ApiModel(description = "Other tariff type which is not in the standard list.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OtherTariffType {
   @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Borrowing details
  */
 @ApiModel(description = "Borrowing details")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class Overdraft {
     @JsonProperty("Notes")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Details about Overdraft rates, fees &amp; charges
  */
 @ApiModel(description = "Details about Overdraft rates, fees & charges")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class Overdraft1 {
     @JsonProperty("Notes")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftFeeChargeCap.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftFeeChargeCap.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * Details about any caps (maximum charges) that apply to a particular fee/charge
  */
 @ApiModel(description = "Details about any caps (maximum charges) that apply to a particular fee/charge")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class Overdraft1OverdraftFeeChargeCap {
     /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftFeeChargeDetail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftFeeChargeDetail.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  * Details about the fees/charges
  */
 @ApiModel(description = "Details about the fees/charges")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class Overdraft1OverdraftFeeChargeDetail {
     /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftFeesCharges.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftFeesCharges.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Overdraft fees and charges
  */
 @ApiModel(description = "Overdraft fees and charges")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class Overdraft1OverdraftFeesCharges {
   @JsonProperty("OverdraftFeeChargeCap")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftFeesCharges1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftFeesCharges1.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Overdraft fees and charges details
  */
 @ApiModel(description = "Overdraft fees and charges details")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class Overdraft1OverdraftFeesCharges1 {
   @JsonProperty("OverdraftFeeChargeCap")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftTierBand.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftTierBand.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * Provides overdraft details for a specific tier or band
  */
 @ApiModel(description = "Provides overdraft details for a specific tier or band")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class Overdraft1OverdraftTierBand {
   @JsonProperty("Identification")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftTierBandSet.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/Overdraft1OverdraftTierBandSet.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * Tier band set details
  */
 @ApiModel(description = "Tier band set details")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class Overdraft1OverdraftTierBandSet   {
   /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOtherFeeType.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOtherFeeType.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Other fee type code which is not available in the standard code set
  */
 @ApiModel(description = "Other fee type code which is not available in the standard code set")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OverdraftOtherFeeType {
   @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftFeeChargeCap.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftFeeChargeCap.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.
  */
 @ApiModel(description = "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OverdraftOverdraftFeeChargeCap {
   /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftFeeChargeDetail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftFeeChargeDetail.java
@@ -32,7 +32,7 @@ import java.util.Objects;
  * Details about the fees/charges
  */
 @ApiModel(description = "Details about the fees/charges")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OverdraftOverdraftFeeChargeDetail {
     /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftFeesCharges.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftFeesCharges.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Overdraft fees and charges
  */
 @ApiModel(description = "Overdraft fees and charges")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OverdraftOverdraftFeesCharges {
     @JsonProperty("OverdraftFeeChargeCap")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftFeesCharges1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftFeesCharges1.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * Overdraft fees and charges details
  */
 @ApiModel(description = "Overdraft fees and charges details")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OverdraftOverdraftFeesCharges1 {
     @JsonProperty("OverdraftFeeChargeCap")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftTierBand.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftTierBand.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * Provides overdraft details for a specific tier or band
  */
 @ApiModel(description = "Provides overdraft details for a specific tier or band")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OverdraftOverdraftTierBand {
     @JsonProperty("Identification")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftTierBandSet.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/OverdraftOverdraftTierBandSet.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * Tier band set details
  */
 @ApiModel(description = "Tier band set details")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OverdraftOverdraftTierBandSet   {
   /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/PCA.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/PCA.java
@@ -37,7 +37,7 @@ import java.util.Objects;
 /**
  * PCA
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T15:59:01.633+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class PCA {
     @JsonProperty("ProductDetails")
     private ProductDetails1 productDetails = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ProductDetails.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ProductDetails.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 /**
  * ProductDetails
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class ProductDetails {
   /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ProductDetails1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ProductDetails1.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 /**
  * ProductDetails1
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class ProductDetails1 {
   /**

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ProprietaryBankTransactionCodeStructure1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/account/ProprietaryBankTransactionCodeStructure1.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * Set of elements to fully identify a proprietary bank transaction code.
  */
 @ApiModel(description = "Set of elements to fully identify a proprietary bank transaction code.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-19T10:04:10.581299+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class ProprietaryBankTransactionCodeStructure1 {
     @JsonProperty("Code")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPResponse.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPResponse.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * OBDomesticVRPResponse
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBDomesticVRPResponse {
     @JsonProperty("Data")
     private OBDomesticVRPResponseData data;


### PR DESCRIPTION
Configuring the codegen option hideGenerationTimestamp=true & removing existing timestamps.

The aim of this is to remove noise when diffing code which has been regenerated, as the previous impl means there will always be at least 1 difference(the timestamp) in every file which gets regenerated.

I don't see any value in this timestamp, the git history provides much better information.

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/451