### PR TITLE
451: Removing timestamp from generated code annotation

### DIFF
--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/Links.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/Links.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Links relevant to the payload
  */
 @ApiModel(description = "Links relevant to the payload")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class Links {
     @JsonProperty("Self")
     private URI self;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/Meta.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/Meta.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Meta Data relevant to the payload
  */
 @ApiModel(description = "Meta Data relevant to the payload")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-16T08:37:28.078Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 public class Meta {
     @JsonProperty("TotalPages")
     private Integer totalPages = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBActiveOrHistoricCurrencyAndAmount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBActiveOrHistoricCurrencyAndAmount.java
@@ -29,7 +29,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Amount of money associated with the charge type.
  */
 @ApiModel(description = "Amount of money associated with the charge type.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBActiveOrHistoricCurrencyAndAmount {
     @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBBranchAndFinancialInstitutionIdentification2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBBranchAndFinancialInstitutionIdentification2.java
@@ -32,7 +32,7 @@ import uk.org.openbanking.datamodel.account.OBExternalFinancialInstitutionIdenti
  * OBBranchAndFinancialInstitutionIdentification2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBBranchAndFinancialInstitutionIdentification2 {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBBranchAndFinancialInstitutionIdentification6.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBBranchAndFinancialInstitutionIdentification6.java
@@ -42,7 +42,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account.
  */
 @ApiModel(description = "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBBranchAndFinancialInstitutionIdentification6 {
     @JsonProperty("SchemeName")
     private String schemeName = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBCashAccount3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBCashAccount3.java
@@ -32,7 +32,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 @ApiModel(description = "Provides the details to identify the beneficiary account.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBCashAccount3 {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBCashAccountCreditor3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBCashAccountCreditor3.java
@@ -27,7 +27,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBCashAccountCreditor3
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBCashAccountCreditor3 {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBPostalAddress6.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBPostalAddress6.java
@@ -35,7 +35,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 @ApiModel(description = "Information that locates and identifies a specific address, as defined by postal services.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBPostalAddress6 {
     @JsonProperty("AddressType")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBRisk1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBRisk1.java
@@ -32,7 +32,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 @ApiModel(description = "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Payments.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBRisk1 {
     @JsonProperty("PaymentContextCode")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBRisk1DeliveryAddress.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBRisk1DeliveryAddress.java
@@ -36,7 +36,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 @ApiModel(description = "Information that locates and identifies a specific address, as defined by postal services or in free format text.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBRisk1DeliveryAddress {
     @JsonProperty("AddressLine")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBSupplementaryData1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/common/OBSupplementaryData1.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.jackson.payment.OBSupplementaryData1Serializer;
  */
 @ApiModel(description = "Additional information that can not be captured in the structured fields and/or any other specific block.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @JsonDeserialize(using = OBSupplementaryData1Deserializer.class)
 @JsonSerialize(using = OBSupplementaryData1Serializer.class)

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/error/OBError1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/error/OBError1.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBError1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 public class OBError1 {
     @JsonProperty("ErrorCode")
     private String errorCode = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/error/OBErrorResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/error/OBErrorResponse1.java
@@ -35,7 +35,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 @ApiModel(description = "An array of detail error codes, and messages, and URLs to documentation to help remediation.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-01T11:26:57.876+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 public class OBErrorResponse1 {
     @JsonProperty("Code")
     private String code = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrl1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrl1.java
@@ -40,7 +40,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBCallbackUrl1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-25T13:48:32.198+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBCallbackUrl1 {
     @JsonProperty("Data")
     private OBCallbackUrlData1 data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrlData1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrlData1.java
@@ -40,7 +40,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBCallbackUrlData1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-25T13:48:32.198+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBCallbackUrlData1 {
     @JsonProperty("Url")
     private String url = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrlResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrlResponse1.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBCallbackUrlResponse1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-25T13:48:32.198+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBCallbackUrlResponse1 {
     @JsonProperty("Data")
     private OBCallbackUrlResponseData1 data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrlResponseData1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrlResponseData1.java
@@ -40,7 +40,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBCallbackUrlResponseData1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-25T13:48:32.198+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBCallbackUrlResponseData1 {
     @JsonProperty("CallbackUrlId")
     private String callbackUrlId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrlsResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrlsResponse1.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBCallbackUrlsResponse1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-25T13:48:32.198+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBCallbackUrlsResponse1 {
     @JsonProperty("Data")
     private OBCallbackUrlsResponseData1 data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrlsResponseData1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBCallbackUrlsResponseData1.java
@@ -41,7 +41,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBCallbackUrlsResponseData1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-25T13:48:32.198+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBCallbackUrlsResponseData1 {
     @JsonProperty("CallbackUrl")
     private List<OBCallbackUrlResponseData1> callbackUrl = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEvent1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEvent1.java
@@ -42,7 +42,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Events.
  */
 @ApiModel(description = "Events.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2021-05-13T11:51:33.738+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBEvent1 {
     @JsonProperty("urn:uk:org:openbanking:events:resource-update")
     private OBEventResourceUpdate1 urnukorgopenbankingeventsresourceUpdate = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventLink1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventLink1.java
@@ -42,7 +42,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Resource links to other available versions of the resource.
  */
 @ApiModel(description = "Resource links to other available versions of the resource.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2021-05-13T11:51:33.738+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBEventLink1 {
     @JsonProperty("version")
     private String version = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventNotification1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventNotification1.java
@@ -44,7 +44,7 @@ import io.swagger.annotations.ApiModelProperty;
  * The resource-update event.
  */
 @ApiModel(description = "The resource-update event.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2021-05-13T11:51:33.738+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBEventNotification1 {
     @JsonProperty("aud")
     private String aud = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventPolling1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventPolling1.java
@@ -43,7 +43,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBEventPolling1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T15:58:23.513+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBEventPolling1 {
     @JsonProperty("maxEvents")
     private Integer maxEvents = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventPolling1SetErrs.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventPolling1SetErrs.java
@@ -40,7 +40,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBEventPolling1SetErrs
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T15:58:23.513+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBEventPolling1SetErrs {
     @JsonProperty("err")
     private String err = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventPollingResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventPollingResponse1.java
@@ -41,7 +41,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBEventPollingResponse1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T15:58:23.513+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBEventPollingResponse1 {
     @JsonProperty("moreAvailable")
     private Boolean moreAvailable = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventResourceUpdate1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventResourceUpdate1.java
@@ -42,7 +42,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Resource-Update Event.
  */
 @ApiModel(description = "Resource-Update Event.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2021-05-13T11:51:33.738+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBEventResourceUpdate1 {
     @JsonProperty("subject")
     private OBEventSubject1 subject = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubject1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubject1.java
@@ -45,7 +45,7 @@ import io.swagger.annotations.ApiModelProperty;
  * The resource-update event.
  */
 @ApiModel(description = "The resource-update event.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2021-05-13T11:51:33.738+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBEventSubject1 {
     @JsonProperty("subject_type")
     private String subjectType = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscription1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscription1.java
@@ -40,7 +40,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBEventSubscription1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-25T13:49:38.894+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBEventSubscription1 {
     @JsonProperty("Data")
     private OBEventSubscription1Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscription1Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscription1Data.java
@@ -42,7 +42,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBEventSubscription1Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-25T13:49:38.894+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBEventSubscription1Data {
     @JsonProperty("CallbackUrl")
     private String callbackUrl = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscriptionResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscriptionResponse1.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBEventSubscriptionResponse1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-25T13:49:38.894+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBEventSubscriptionResponse1 {
     @JsonProperty("Data")
     private OBEventSubscriptionResponse1Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscriptionResponse1Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscriptionResponse1Data.java
@@ -42,7 +42,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBEventSubscriptionResponse1Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-25T13:49:38.894+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBEventSubscriptionResponse1Data {
     @JsonProperty("EventSubscriptionId")
     private String eventSubscriptionId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscriptionsResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscriptionsResponse1.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBEventSubscriptionsResponse1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-25T13:49:38.894+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBEventSubscriptionsResponse1 {
     @JsonProperty("Data")
     private OBEventSubscriptionsResponse1Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscriptionsResponse1Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscriptionsResponse1Data.java
@@ -41,7 +41,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBEventSubscriptionsResponse1Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-25T13:49:38.894+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBEventSubscriptionsResponse1Data {
     @JsonProperty("EventSubscription")
     private List<OBEventSubscriptionsResponse1DataEventSubscription> eventSubscription = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscriptionsResponse1DataEventSubscription.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/event/OBEventSubscriptionsResponse1DataEventSubscription.java
@@ -42,7 +42,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBEventSubscriptionsResponse1DataEventSubscription
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-25T13:49:38.894+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBEventSubscriptionsResponse1DataEventSubscription {
     @JsonProperty("EventSubscriptionId")
     private String eventSubscriptionId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBCashAccountDebtor4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBCashAccountDebtor4.java
@@ -42,7 +42,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Unambiguous identification of the account of the debtor to which a confirmation of funds consent will be applied.
  */
 @ApiModel(description = "Unambiguous identification of the account of the debtor to which a confirmation of funds consent will be applied.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:52:58.420+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBCashAccountDebtor4 {
     @JsonProperty("SchemeName")
     private String schemeName = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmation1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmation1.java
@@ -37,7 +37,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBFundsConfirmation1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-11-15T11:58:26.525Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBFundsConfirmation1 {
     @JsonProperty("Data")
     // validation within OBFundsConfirmationData1 now mirrors OBFundsConfirmation1Data (to minimise impact)

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmation1Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmation1Data.java
@@ -41,7 +41,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBFundsConfirmation1Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2021-05-13T12:19:17.898+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBFundsConfirmation1Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmation1DataInstructedAmount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmation1DataInstructedAmount.java
@@ -29,7 +29,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Amount of money to be confirmed as available funds in the debtor account. Contains an Amount and a Currency.
  */
 @ApiModel(description = "Amount of money to be confirmed as available funds in the debtor account. Contains an Amount and a Currency.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T10:02:34.555654+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBFundsConfirmation1DataInstructedAmount {
     @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsent1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsent1.java
@@ -37,7 +37,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBFundsConfirmationConsent1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-11-15T11:58:26.525Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBFundsConfirmationConsent1 {
     // validation within OBFundsConfirmationConsentData1 now mirrors OBFundsConfirmationConsent1Data (to minimise impact)
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsent1Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsent1Data.java
@@ -42,7 +42,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBFundsConfirmationConsent1Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2021-05-13T12:19:17.898+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBFundsConfirmationConsent1Data {
     @JsonProperty("DebtorAccount")
     private OBFundsConfirmationConsent1DataDebtorAccount debtorAccount = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsent1DataDebtorAccount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsent1DataDebtorAccount.java
@@ -42,7 +42,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Unambiguous identification of the account of the debtor to which a confirmation of funds consent will be applied.
  */
 @ApiModel(description = "Unambiguous identification of the account of the debtor to which a confirmation of funds consent will be applied.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2021-05-13T12:19:17.898+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBFundsConfirmationConsent1DataDebtorAccount {
     @JsonProperty("Identification")
     private String identification = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsentData1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsentData1.java
@@ -41,7 +41,7 @@ import uk.org.openbanking.datamodel.common.OBCashAccount3;
 /**
  * OBFundsConfirmationConsentData1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-11-15T11:58:26.525Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBFundsConfirmationConsentData1 {
     @JsonProperty("ExpirationDateTime")
     private DateTime expirationDateTime = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsentDataResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsentDataResponse1.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBExternalRequestStatus1Code;
 /**
  * OBFundsConfirmationConsentDataResponse1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-11-15T11:58:26.525Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBFundsConfirmationConsentDataResponse1 {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsentResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsentResponse1.java
@@ -39,7 +39,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBFundsConfirmationConsentResponse1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-11-15T11:58:26.525Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBFundsConfirmationConsentResponse1 {
     // validation within OBFundsConfirmationConsentDataResponse1 now mirrors OBFundsConfirmationConsentResponse1Data (to minimise impact)
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsentResponse1Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationConsentResponse1Data.java
@@ -33,7 +33,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBFundsConfirmationConsentResponse1Data
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T10:02:34.555654+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBFundsConfirmationConsentResponse1Data {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationData1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationData1.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.OBActiveOrHistoricCurrencyAndAmount;
 /**
  * OBFundsConfirmationData1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-11-15T11:58:26.525Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBFundsConfirmationData1 {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationDataResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationDataResponse1.java
@@ -44,7 +44,7 @@ import uk.org.openbanking.datamodel.common.OBActiveOrHistoricCurrencyAndAmount;
 /**
  * OBFundsConfirmationDataResponse1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2018-11-15T11:58:26.525Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBFundsConfirmationDataResponse1 {
     @JsonProperty("FundsConfirmationId")
     private String fundsConfirmationId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationResponse1.java
@@ -40,7 +40,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBFundsConfirmationResponse1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2021-05-13T12:19:17.898+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBFundsConfirmationResponse1 {
     // validation within OBFundsConfirmationDataResponse1 now mirrors OBFundsConfirmationResponse1Data (to minimise impact)
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationResponse1Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/fund/OBFundsConfirmationResponse1Data.java
@@ -43,7 +43,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBFundsConfirmationResponse1Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:14:00.739+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBFundsConfirmationResponse1Data {
     @JsonProperty("FundsConfirmationId")
     private String fundsConfirmationId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBAuthorisation1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBAuthorisation1.java
@@ -33,7 +33,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 @ApiModel(description = "The authorisation type request from the TPP.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBAuthorisation1 {
     @JsonProperty("AuthorisationType")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBBranchAndFinancialInstitutionIdentification3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBBranchAndFinancialInstitutionIdentification3.java
@@ -33,7 +33,7 @@ import uk.org.openbanking.datamodel.common.OBPostalAddress6;
  */
 @ApiModel(description = "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBBranchAndFinancialInstitutionIdentification3 {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBCashAccountDebtor4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBCashAccountDebtor4.java
@@ -26,7 +26,7 @@ import io.swagger.annotations.ApiModelProperty;
  * ^ Only incuded in the response if &#x60;Data. ReadRefundAccount&#x60; is set to &#x60;Yes&#x60; in the consent.
  */
 @ApiModel(description = "^ Only incuded in the response if `Data. ReadRefundAccount` is set to `Yes` in the consent.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBCashAccountDebtor4 {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBCharge1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBCharge1.java
@@ -35,7 +35,7 @@ import uk.org.openbanking.datamodel.common.OBChargeBearerType1Code;
  */
 @ApiModel(description = "Set of elements used to provide details of a charge for the payment initiation.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBCharge1 {
     @JsonProperty("ChargeBearer")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBCharge2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBCharge2.java
@@ -44,7 +44,7 @@ import uk.org.openbanking.datamodel.common.OBChargeBearerType1Code;
  * Set of elements used to provide details of a charge for the payment initiation.
  */
 @ApiModel(description = "Set of elements used to provide details of a charge for the payment initiation.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBCharge2 {
     @JsonProperty("ChargeBearer")
     private OBChargeBearerType1Code chargeBearer = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBCharge2Amount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBCharge2Amount.java
@@ -42,7 +42,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Amount of money associated with the charge type.
  */
 @ApiModel(description = "Amount of money associated with the charge type.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBCharge2Amount {
     @JsonProperty("Amount")
     private String amount = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDebtorIdentification1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDebtorIdentification1.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 @ApiModel(description = "Set of elements used to identify a person or an organisation.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2021-05-10T15:22:08.964Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 public class OBDebtorIdentification1 {
     @JsonProperty("Name")
     private String name = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomestic1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomestic1.java
@@ -36,7 +36,7 @@ import uk.org.openbanking.datamodel.common.OBPostalAddress6;
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBDomestic1 {
     @JsonProperty("InstructionIdentification")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomestic2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomestic2.java
@@ -37,7 +37,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBDomestic2 {
     @JsonProperty("InstructionIdentification")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomestic2InstructedAmount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomestic2InstructedAmount.java
@@ -42,7 +42,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party. Usage: This amount has to be transported unchanged through the transaction chain.
  */
 @ApiModel(description = "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party. Usage: This amount has to be transported unchanged through the transaction chain.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBDomestic2InstructedAmount {
     @JsonProperty("Amount")
     private String amount = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticScheduled1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticScheduled1.java
@@ -37,7 +37,7 @@ import uk.org.openbanking.datamodel.common.OBPostalAddress6;
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBDomesticScheduled1 {
     @JsonProperty("InstructionIdentification")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticScheduled2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticScheduled2.java
@@ -38,7 +38,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBDomesticScheduled2 {
     @JsonProperty("InstructionIdentification")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder1.java
@@ -37,7 +37,7 @@ import uk.org.openbanking.datamodel.common.OBCashAccount3;
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBDomesticStandingOrder1 {
     @JsonProperty("Frequency")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder2.java
@@ -38,7 +38,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBDomesticStandingOrder2 {
     @JsonProperty("Frequency")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder3.java
@@ -48,7 +48,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
  * The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order.
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBDomesticStandingOrder3 {
     @JsonProperty("Frequency")
     private String frequency = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder3FinalPaymentAmount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder3FinalPaymentAmount.java
@@ -42,7 +42,7 @@ import io.swagger.annotations.ApiModelProperty;
  * The amount of the final Standing Order
  */
 @ApiModel(description = "The amount of the final Standing Order")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBDomesticStandingOrder3FinalPaymentAmount {
     @JsonProperty("Amount")
     private String amount = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder3FirstPaymentAmount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder3FirstPaymentAmount.java
@@ -42,7 +42,7 @@ import io.swagger.annotations.ApiModelProperty;
  * The amount of the first Standing Order
  */
 @ApiModel(description = "The amount of the first Standing Order")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBDomesticStandingOrder3FirstPaymentAmount {
     @JsonProperty("Amount")
     private String amount = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder3RecurringPaymentAmount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBDomesticStandingOrder3RecurringPaymentAmount.java
@@ -42,7 +42,7 @@ import io.swagger.annotations.ApiModelProperty;
  * The amount of the recurring Standing Order
  */
 @ApiModel(description = "The amount of the recurring Standing Order")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBDomesticStandingOrder3RecurringPaymentAmount {
     @JsonProperty("Amount")
     private String amount = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBExchangeRate1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBExchangeRate1.java
@@ -35,7 +35,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 @ApiModel(description = "Provides details on the currency exchange rate and contract.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBExchangeRate1 {
     @JsonProperty("UnitCurrency")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBExchangeRate2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBExchangeRate2.java
@@ -36,7 +36,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 @ApiModel(description = "Further detailed information on the exchange rate that has been used in the payment transaction.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBExchangeRate2 {
     @JsonProperty("UnitCurrency")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBFile1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBFile1.java
@@ -37,7 +37,7 @@ import uk.org.openbanking.datamodel.common.OBCashAccount3;
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBFile1 {
     @JsonProperty("FileType")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBFile2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBFile2.java
@@ -38,7 +38,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBFile2 {
     @JsonProperty("FileType")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBFundsAvailableResult1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBFundsAvailableResult1.java
@@ -33,7 +33,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 @ApiModel(description = "Result of a funds availability check.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBFundsAvailableResult1 {
     @JsonProperty("FundsAvailableDateTime")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternational1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternational1.java
@@ -37,7 +37,7 @@ import uk.org.openbanking.datamodel.common.OBChargeBearerType1Code;
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBInternational1 {
     @JsonProperty("InstructionIdentification")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternational2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternational2.java
@@ -38,7 +38,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBInternational2 {
     @JsonProperty("InstructionIdentification")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternationalScheduled1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternationalScheduled1.java
@@ -38,7 +38,7 @@ import uk.org.openbanking.datamodel.common.OBChargeBearerType1Code;
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBInternationalScheduled1 {
     @JsonProperty("InstructionIdentification")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternationalScheduled2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternationalScheduled2.java
@@ -39,7 +39,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBInternationalScheduled2 {
     @JsonProperty("InstructionIdentification")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternationalStandingOrder1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternationalStandingOrder1.java
@@ -38,7 +38,7 @@ import uk.org.openbanking.datamodel.common.OBChargeBearerType1Code;
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBInternationalStandingOrder1 {
     @JsonProperty("Frequency")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternationalStandingOrder2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternationalStandingOrder2.java
@@ -39,7 +39,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBInternationalStandingOrder2 {
     @JsonProperty("Frequency")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternationalStandingOrder3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBInternationalStandingOrder3.java
@@ -50,7 +50,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
  * The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order.
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBInternationalStandingOrder3 {
     @JsonProperty("Frequency")
     private String frequency = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBMultiAuthorisation1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBMultiAuthorisation1.java
@@ -34,7 +34,7 @@ import uk.org.openbanking.datamodel.common.OBExternalStatus2Code;
  */
 @ApiModel(description = "The multiple authorisation flow response from the ASPSP.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBMultiAuthorisation1 {
     @JsonProperty("Status")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBPartyIdentification43.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBPartyIdentification43.java
@@ -33,7 +33,7 @@ import uk.org.openbanking.datamodel.common.OBPostalAddress6;
  */
 @ApiModel(description = "Party to which an amount of money is due.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBPartyIdentification43 {
     @JsonProperty("Name")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBRemittanceInformation1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBRemittanceInformation1.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiModelProperty;
  */
 @ApiModel(description = "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBRemittanceInformation1 {
     @JsonProperty("Unstructured")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBSCASupportData1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBSCASupportData1.java
@@ -28,7 +28,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Supporting Data provided by TPP, when requesting SCA Exemption.
  */
 @ApiModel(description = "Supporting Data provided by TPP, when requesting SCA Exemption.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBSCASupportData1 {
 

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomestic1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomestic1.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomestic1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomestic1 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomestic2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomestic2.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomestic2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomestic2 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticConsent1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticConsent1.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomesticConsent1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomesticConsent1 {
     @JsonProperty("Initiation")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticConsent2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticConsent2.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomesticConsent2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomesticConsent2 {
     @JsonProperty("Initiation")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticConsentResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticConsentResponse1.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomesticConsentResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomesticConsentResponse1 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticConsentResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticConsentResponse2.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomesticConsentResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomesticConsentResponse2 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticResponse1.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomesticResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomesticResponse1 {
     @JsonProperty("DomesticPaymentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticResponse2.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomesticResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomesticResponse2 {
     @JsonProperty("DomesticPaymentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduled1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduled1.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomesticScheduled1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomesticScheduled1 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduled2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduled2.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomesticScheduled2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomesticScheduled2 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledConsent1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledConsent1.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomesticScheduledConsent1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomesticScheduledConsent1 {
     @JsonProperty("Permission")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledConsent2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledConsent2.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomesticScheduledConsent2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomesticScheduledConsent2 {
     @JsonProperty("Permission")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledConsentResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledConsentResponse1.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomesticScheduledConsentResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomesticScheduledConsentResponse1 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledConsentResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledConsentResponse2.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomesticScheduledConsentResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomesticScheduledConsentResponse2 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledResponse1.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomesticScheduledResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomesticScheduledResponse1 {
     @JsonProperty("DomesticScheduledPaymentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticScheduledResponse2.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomesticScheduledResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomesticScheduledResponse2 {
     @JsonProperty("DomesticScheduledPaymentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrder1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrder1.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomesticStandingOrder1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomesticStandingOrder1 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrder2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrder2.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomesticStandingOrder2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomesticStandingOrder2 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrder3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrder3.java
@@ -41,7 +41,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDataDomesticStandingOrder3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDataDomesticStandingOrder3 {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsent1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsent1.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomesticStandingOrderConsent1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomesticStandingOrderConsent1 {
     @JsonProperty("Permission")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsent2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsent2.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomesticStandingOrderConsent2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomesticStandingOrderConsent2 {
     @JsonProperty("Permission")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsent3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsent3.java
@@ -40,7 +40,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDataDomesticStandingOrderConsent3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDataDomesticStandingOrderConsent3 {
     @JsonProperty("Permission")
     private OBExternalPermissions2Code permission = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsentResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsentResponse1.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomesticStandingOrderConsentResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomesticStandingOrderConsentResponse1 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsentResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsentResponse2.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomesticStandingOrderConsentResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomesticStandingOrderConsentResponse2 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsentResponse3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderConsentResponse3.java
@@ -45,7 +45,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDataDomesticStandingOrderConsentResponse3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDataDomesticStandingOrderConsentResponse3 {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderResponse1.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomesticStandingOrderResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomesticStandingOrderResponse1 {
     @JsonProperty("DomesticStandingOrderId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderResponse2.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataDomesticStandingOrderResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataDomesticStandingOrderResponse2 {
     @JsonProperty("DomesticStandingOrderId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderResponse3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataDomesticStandingOrderResponse3.java
@@ -45,7 +45,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDataDomesticStandingOrderResponse3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDataDomesticStandingOrderResponse3 {
     @JsonProperty("DomesticStandingOrderId")
     private String domesticStandingOrderId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFile1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFile1.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataFile1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataFile1 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFile2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFile2.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataFile2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataFile2 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileConsent1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileConsent1.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataFileConsent1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataFileConsent1 {
     @JsonProperty("Initiation")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileConsent2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileConsent2.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataFileConsent2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataFileConsent2 {
     @JsonProperty("Initiation")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileConsentResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileConsentResponse1.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataFileConsentResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataFileConsentResponse1 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileConsentResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileConsentResponse2.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataFileConsentResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataFileConsentResponse2 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileResponse1.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataFileResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataFileResponse1 {
     @JsonProperty("FilePaymentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFileResponse2.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataFileResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataFileResponse2 {
     @JsonProperty("FilePaymentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFundsConfirmationResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataFundsConfirmationResponse1.java
@@ -30,7 +30,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
  * OBWriteDataFundsConfirmationResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataFundsConfirmationResponse1 {
     @JsonProperty("FundsAvailableResult")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternational1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternational1.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternational1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternational1 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternational2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternational2.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternational2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternational2 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalConsent1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalConsent1.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternationalConsent1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternationalConsent1 {
     @JsonProperty("Initiation")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalConsent2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalConsent2.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternationalConsent2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternationalConsent2 {
     @JsonProperty("Initiation")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalConsentResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalConsentResponse1.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternationalConsentResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternationalConsentResponse1 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalConsentResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalConsentResponse2.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternationalConsentResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternationalConsentResponse2 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalResponse1.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternationalResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternationalResponse1 {
     @JsonProperty("InternationalPaymentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalResponse2.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternationalResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternationalResponse2 {
     @JsonProperty("InternationalPaymentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduled1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduled1.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternationalScheduled1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternationalScheduled1 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduled2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduled2.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternationalScheduled2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternationalScheduled2 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledConsent1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledConsent1.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternationalScheduledConsent1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternationalScheduledConsent1 {
     @JsonProperty("Permission")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledConsent2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledConsent2.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternationalScheduledConsent2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternationalScheduledConsent2 {
     @JsonProperty("Permission")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledConsentResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledConsentResponse1.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternationalScheduledConsentResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternationalScheduledConsentResponse1 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledConsentResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledConsentResponse2.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternationalScheduledConsentResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternationalScheduledConsentResponse2 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledResponse1.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternationalScheduledResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternationalScheduledResponse1 {
     @JsonProperty("InternationalScheduledPaymentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalScheduledResponse2.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternationalScheduledResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternationalScheduledResponse2 {
     @JsonProperty("InternationalScheduledPaymentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrder1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrder1.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternationalStandingOrder1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternationalStandingOrder1 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrder2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrder2.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternationalStandingOrder2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternationalStandingOrder2 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrder3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrder3.java
@@ -41,7 +41,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDataInternationalStandingOrder3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDataInternationalStandingOrder3 {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsent1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsent1.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternationalStandingOrderConsent1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternationalStandingOrderConsent1 {
     @JsonProperty("Permission")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsent2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsent2.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternationalStandingOrderConsent2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternationalStandingOrderConsent2 {
     @JsonProperty("Permission")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsent3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsent3.java
@@ -40,7 +40,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDataInternationalStandingOrderConsent3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDataInternationalStandingOrderConsent3 {
     @JsonProperty("Permission")
     private OBExternalPermissions2Code permission = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsentResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsentResponse1.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternationalStandingOrderConsentResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternationalStandingOrderConsentResponse1 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsentResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsentResponse2.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternationalStandingOrderConsentResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternationalStandingOrderConsentResponse2 {
     @JsonProperty("ConsentId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsentResponse3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderConsentResponse3.java
@@ -45,7 +45,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDataInternationalStandingOrderConsentResponse3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDataInternationalStandingOrderConsentResponse3 {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderResponse1.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternationalStandingOrderResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternationalStandingOrderResponse1 {
     @JsonProperty("InternationalStandingOrderId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderResponse2.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteDataInternationalStandingOrderResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDataInternationalStandingOrderResponse2 {
     @JsonProperty("InternationalStandingOrderId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderResponse3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDataInternationalStandingOrderResponse3.java
@@ -45,7 +45,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDataInternationalStandingOrderResponse3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDataInternationalStandingOrderResponse3 {
     @JsonProperty("InternationalStandingOrderId")
     private String internationalStandingOrderId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic1.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteDomestic1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDomestic1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2.java
@@ -28,7 +28,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteDomestic2
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBWriteDomestic2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2Data.java
@@ -41,7 +41,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomestic2Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomestic2Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2DataInitiation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2DataInitiation.java
@@ -32,7 +32,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
  * The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment.
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBWriteDomestic2DataInitiation {
     @JsonProperty("InstructionIdentification")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2DataInitiationCreditorAccount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2DataInitiationCreditorAccount.java
@@ -29,7 +29,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction.
  */
 @ApiModel(description = "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBWriteDomestic2DataInitiationCreditorAccount {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2DataInitiationDebtorAccount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2DataInitiationDebtorAccount.java
@@ -29,7 +29,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction.
  */
 @ApiModel(description = "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBWriteDomestic2DataInitiationDebtorAccount {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2DataInitiationInstructedAmount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2DataInitiationInstructedAmount.java
@@ -29,7 +29,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party. Usage: This amount has to be transported unchanged through the transaction chain.
  */
 @ApiModel(description = "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party. Usage: This amount has to be transported unchanged through the transaction chain.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBWriteDomestic2DataInitiationInstructedAmount {
     @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2DataInitiationRemittanceInformation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomestic2DataInitiationRemittanceInformation.java
@@ -41,7 +41,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts&#39; receivable system.
  */
 @ApiModel(description = "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomestic2DataInitiationRemittanceInformation {
     @JsonProperty("Unstructured")
     private String unstructured = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent1.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteDomesticConsent1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticConsent1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent2.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteDomesticConsent2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticConsent2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent3.java
@@ -41,7 +41,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteDomesticConsent3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticConsent3 {
     @JsonProperty("Data")
     private OBWriteDomesticConsent3Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent3Data.java
@@ -40,7 +40,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticConsent3Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticConsent3Data {
     @JsonProperty("Initiation")
     private OBWriteDomestic2DataInitiation initiation = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent3DataAuthorisation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent3DataAuthorisation.java
@@ -44,7 +44,7 @@ import io.swagger.annotations.ApiModelProperty;
  * The authorisation type request from the TPP.
  */
 @ApiModel(description = "The authorisation type request from the TPP.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticConsent3DataAuthorisation {
     @JsonProperty("AuthorisationType")
     private OBExternalAuthorisation1Code authorisationType = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent3DataSCASupportData.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent3DataSCASupportData.java
@@ -39,7 +39,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Supporting Data provided by TPP, when requesting SCA Exemption.
  */
 @ApiModel(description = "Supporting Data provided by TPP, when requesting SCA Exemption.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticConsent3DataSCASupportData {
     @JsonProperty("RequestedSCAExemptionType")
     private OBRequestedSCAExemptionTypeEnum requestedSCAExemptionType = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent4.java
@@ -41,7 +41,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteDomesticConsent4
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticConsent4 {
     @JsonProperty("Data")
     private OBWriteDomesticConsent4Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent4Data.java
@@ -38,7 +38,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticConsent4Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticConsent4Data {
 
     @JsonProperty("ReadRefundAccount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent4DataAuthorisation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent4DataAuthorisation.java
@@ -44,7 +44,7 @@ import io.swagger.annotations.ApiModelProperty;
  * The authorisation type request from the TPP.
  */
 @ApiModel(description = "The authorisation type request from the TPP.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticConsent4DataAuthorisation {
 
     @JsonProperty("AuthorisationType")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent4DataSCASupportData.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsent4DataSCASupportData.java
@@ -41,7 +41,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Supporting Data provided by TPP, when requesting SCA Exemption.
  */
 @ApiModel(description = "Supporting Data provided by TPP, when requesting SCA Exemption.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticConsent4DataSCASupportData {
 
     @JsonProperty("RequestedSCAExemptionType")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse1.java
@@ -33,7 +33,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteDomesticConsentResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticConsentResponse1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse2.java
@@ -33,7 +33,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteDomesticConsentResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticConsentResponse2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse3.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteDomesticConsentResponse3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticConsentResponse3 {
     @JsonProperty("Data")
     private OBWriteDomesticConsentResponse3Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse3Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticConsentResponse3Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticConsentResponse3Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse3DataCharges.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse3DataCharges.java
@@ -44,7 +44,7 @@ import uk.org.openbanking.datamodel.common.OBChargeBearerType1Code;
  * Set of elements used to provide details of a charge for the payment initiation.
  */
 @ApiModel(description = "Set of elements used to provide details of a charge for the payment initiation.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticConsentResponse3DataCharges {
     @JsonProperty("ChargeBearer")
     private OBChargeBearerType1Code chargeBearer = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse4.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteDomesticConsentResponse4
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticConsentResponse4 {
     @JsonProperty("Data")
     private OBWriteDomesticConsentResponse4Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse4Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticConsentResponse4Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticConsentResponse4Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse4DataCharges.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse4DataCharges.java
@@ -44,7 +44,7 @@ import uk.org.openbanking.datamodel.common.OBChargeBearerType1Code;
  * Set of elements used to provide details of a charge for the payment initiation.
  */
 @ApiModel(description = "Set of elements used to provide details of a charge for the payment initiation.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticConsentResponse4DataCharges {
     @JsonProperty("ChargeBearer")
     private OBChargeBearerType1Code chargeBearer = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse5.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteDomesticConsentResponse5
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticConsentResponse5 {
     @JsonProperty("Data")
     private OBWriteDomesticConsentResponse5Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse5Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse5Data.java
@@ -45,7 +45,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticConsentResponse5Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticConsentResponse5Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse5DataCharges.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticConsentResponse5DataCharges.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBChargeBearerType1Code;
  * Set of elements used to provide details of a charge for the payment initiation.
  */
 @ApiModel(description = "Set of elements used to provide details of a charge for the payment initiation.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticConsentResponse5DataCharges {
     @JsonProperty("ChargeBearer")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse1.java
@@ -32,7 +32,7 @@ import uk.org.openbanking.datamodel.common.Meta;
  * OBWriteDomesticResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticResponse1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse2.java
@@ -32,7 +32,7 @@ import uk.org.openbanking.datamodel.common.Meta;
  * OBWriteDomesticResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticResponse2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse3.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteDomesticResponse3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticResponse3 {
     @JsonProperty("Data")
     private OBWriteDomesticResponse3Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse3Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticResponse3Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticResponse3Data {
     @JsonProperty("DomesticPaymentId")
     private String domesticPaymentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse3DataMultiAuthorisation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse3DataMultiAuthorisation.java
@@ -46,7 +46,7 @@ import io.swagger.annotations.ApiModelProperty;
  * The multiple authorisation flow response from the ASPSP.
  */
 @ApiModel(description = "The multiple authorisation flow response from the ASPSP.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticResponse3DataMultiAuthorisation {
     @JsonProperty("Status")
     private StatusEnum status = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse4.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteDomesticResponse4
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticResponse4 {
     @JsonProperty("Data")
     private OBWriteDomesticResponse4Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse4Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticResponse4Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticResponse4Data {
     @JsonProperty("DomesticPaymentId")
     private String domesticPaymentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse4DataMultiAuthorisation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse4DataMultiAuthorisation.java
@@ -46,7 +46,7 @@ import io.swagger.annotations.ApiModelProperty;
  * The multiple authorisation flow response from the ASPSP.
  */
 @ApiModel(description = "The multiple authorisation flow response from the ASPSP.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticResponse4DataMultiAuthorisation {
     /**
      * Specifies the status of the authorisation flow in code form.

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse4DataRefund.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse4DataRefund.java
@@ -42,7 +42,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Unambiguous identification of the refund account to which a refund will be made as a result of the transaction.
  */
 @ApiModel(description = "Unambiguous identification of the refund account to which a refund will be made as a result of the transaction.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticResponse4DataRefund {
     @JsonProperty("Account")
     private OBWriteDomesticResponse4DataRefundAccount account = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse4DataRefundAccount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse4DataRefundAccount.java
@@ -42,7 +42,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Provides the details to identify an account.
  */
 @ApiModel(description = "Provides the details to identify an account.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticResponse4DataRefundAccount {
     @JsonProperty("SchemeName")
     private String schemeName = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse5.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteDomesticResponse5
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticResponse5 {
     @JsonProperty("Data")
     private OBWriteDomesticResponse5Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse5Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse5Data.java
@@ -45,7 +45,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticResponse5Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticResponse5Data {
     @JsonProperty("DomesticPaymentId")
     private String domesticPaymentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse5DataMultiAuthorisation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse5DataMultiAuthorisation.java
@@ -46,7 +46,7 @@ import io.swagger.annotations.ApiModelProperty;
  * The multiple authorisation flow response from the ASPSP.
  */
 @ApiModel(description = "The multiple authorisation flow response from the ASPSP.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticResponse5DataMultiAuthorisation {
     /**
      * Specifies the status of the authorisation flow in code form.

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse5DataRefund.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse5DataRefund.java
@@ -42,7 +42,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Unambiguous identification of the refund account to which a refund will be made as a result of the transaction.
  */
 @ApiModel(description = "Unambiguous identification of the refund account to which a refund will be made as a result of the transaction.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticResponse5DataRefund {
     @JsonProperty("Account")
     private OBWriteDomesticResponse5DataRefundAccount account = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse5DataRefundAccount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticResponse5DataRefundAccount.java
@@ -29,7 +29,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Provides the details to identify an account.
  */
 @ApiModel(description = "Provides the details to identify an account.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticResponse5DataRefundAccount {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduled1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduled1.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteDomesticScheduled1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticScheduled1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduled2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduled2.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteDomesticScheduled2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticScheduled2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduled2Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduled2Data.java
@@ -41,7 +41,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticScheduled2Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticScheduled2Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduled2DataInitiation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduled2DataInitiation.java
@@ -47,7 +47,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
  * The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment.
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticScheduled2DataInitiation {
     @JsonProperty("InstructionIdentification")
     private String instructionIdentification = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent1.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteDomesticScheduledConsent1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticScheduledConsent1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent2.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteDomesticScheduledConsent2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticScheduledConsent2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent3.java
@@ -41,7 +41,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteDomesticScheduledConsent3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticScheduledConsent3 {
     @JsonProperty("Data")
     private OBWriteDomesticScheduledConsent3Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent3Data.java
@@ -40,7 +40,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticScheduledConsent3Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticScheduledConsent3Data {
     @JsonProperty("Permission")
     private OBExternalPermissions2Code permission = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent4.java
@@ -41,7 +41,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteDomesticScheduledConsent4
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticScheduledConsent4 {
     @JsonProperty("Data")
     private OBWriteDomesticScheduledConsent4Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsent4Data.java
@@ -38,7 +38,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticScheduledConsent4Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticScheduledConsent4Data {
 
     @JsonProperty("Permission")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse1.java
@@ -33,7 +33,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteDomesticScheduledConsentResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticScheduledConsentResponse1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse2.java
@@ -33,7 +33,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteDomesticScheduledConsentResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticScheduledConsentResponse2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse3.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteDomesticScheduledConsentResponse3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticScheduledConsentResponse3 {
     @JsonProperty("Data")
     private OBWriteDomesticScheduledConsentResponse3Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse3Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticScheduledConsentResponse3Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticScheduledConsentResponse3Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse4.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteDomesticScheduledConsentResponse4
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticScheduledConsentResponse4 {
     @JsonProperty("Data")
     private OBWriteDomesticScheduledConsentResponse4Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse4Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticScheduledConsentResponse4Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticScheduledConsentResponse4Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse5.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteDomesticScheduledConsentResponse5
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticScheduledConsentResponse5 {
     @JsonProperty("Data")
     private OBWriteDomesticScheduledConsentResponse5Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse5Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledConsentResponse5Data.java
@@ -45,7 +45,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticScheduledConsentResponse5Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticScheduledConsentResponse5Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse1.java
@@ -32,7 +32,7 @@ import uk.org.openbanking.datamodel.common.Meta;
  * OBWriteDomesticScheduledResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticScheduledResponse1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse2.java
@@ -32,7 +32,7 @@ import uk.org.openbanking.datamodel.common.Meta;
  * OBWriteDomesticScheduledResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticScheduledResponse2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse3.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteDomesticScheduledResponse3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticScheduledResponse3 {
     @JsonProperty("Data")
     private OBWriteDomesticScheduledResponse3Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse3Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticScheduledResponse3Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticScheduledResponse3Data {
     @JsonProperty("DomesticScheduledPaymentId")
     private String domesticScheduledPaymentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse4.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteDomesticScheduledResponse4
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticScheduledResponse4 {
     @JsonProperty("Data")
     private OBWriteDomesticScheduledResponse4Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse4Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticScheduledResponse4Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticScheduledResponse4Data {
     @JsonProperty("DomesticScheduledPaymentId")
     private String domesticScheduledPaymentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse5.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteDomesticScheduledResponse5
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticScheduledResponse5 {
     @JsonProperty("Data")
     private OBWriteDomesticScheduledResponse5Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse5Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticScheduledResponse5Data.java
@@ -45,7 +45,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticScheduledResponse5Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticScheduledResponse5Data {
     @JsonProperty("DomesticScheduledPaymentId")
     private String domesticScheduledPaymentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder1.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteDomesticStandingOrder1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticStandingOrder1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder2.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteDomesticStandingOrder2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticStandingOrder2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3.java
@@ -41,7 +41,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteDomesticStandingOrder3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticStandingOrder3 {
     @JsonProperty("Data")
     private OBWriteDomesticStandingOrder3Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3Data.java
@@ -41,7 +41,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticStandingOrder3Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticStandingOrder3Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiation.java
@@ -47,7 +47,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
  * The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order.
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticStandingOrder3DataInitiation {
     @JsonProperty("Frequency")
     private String frequency = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiationCreditorAccount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiationCreditorAccount.java
@@ -29,7 +29,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Identification assigned by an institution to identify an account. This identification is known by the account owner.
  */
 @ApiModel(description = "Identification assigned by an institution to identify an account. This identification is known by the account owner.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticStandingOrder3DataInitiationCreditorAccount {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiationDebtorAccount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiationDebtorAccount.java
@@ -29,7 +29,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Provides the details to identify the debtor account.
  */
 @ApiModel(description = "Provides the details to identify the debtor account.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticStandingOrder3DataInitiationDebtorAccount {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount.java
@@ -29,7 +29,7 @@ import io.swagger.annotations.ApiModelProperty;
  * The amount of the final Standing Order
  */
 @ApiModel(description = "The amount of the final Standing Order")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount {
     @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount.java
@@ -29,7 +29,7 @@ import io.swagger.annotations.ApiModelProperty;
  * The amount of the first Standing Order
  */
 @ApiModel(description = "The amount of the first Standing Order")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount {
     @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount.java
@@ -29,7 +29,7 @@ import io.swagger.annotations.ApiModelProperty;
  * The amount of the recurring Standing Order
  */
 @ApiModel(description = "The amount of the recurring Standing Order")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount {
     @JsonProperty("Amount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent1.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteDomesticStandingOrderConsent1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticStandingOrderConsent1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent2.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteDomesticStandingOrderConsent2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticStandingOrderConsent2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent3.java
@@ -41,7 +41,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteDomesticStandingOrderConsent3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticStandingOrderConsent3 {
     @JsonProperty("Data")
     private OBWriteDataDomesticStandingOrderConsent3 data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent4.java
@@ -41,7 +41,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteDomesticStandingOrderConsent4
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticStandingOrderConsent4 {
     @JsonProperty("Data")
     private OBWriteDomesticStandingOrderConsent4Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent4Data.java
@@ -40,7 +40,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticStandingOrderConsent4Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticStandingOrderConsent4Data {
     @JsonProperty("Permission")
     private OBExternalPermissions2Code permission = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent5.java
@@ -41,7 +41,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteDomesticStandingOrderConsent5
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticStandingOrderConsent5 {
     @JsonProperty("Data")
     private OBWriteDomesticStandingOrderConsent5Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent5Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsent5Data.java
@@ -38,7 +38,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticStandingOrderConsent5Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticStandingOrderConsent5Data {
 
     @JsonProperty("Permission")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse1.java
@@ -33,7 +33,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteDomesticStandingOrderConsentResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticStandingOrderConsentResponse1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse2.java
@@ -33,7 +33,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteDomesticStandingOrderConsentResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticStandingOrderConsentResponse2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse3.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteDomesticStandingOrderConsentResponse3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticStandingOrderConsentResponse3 {
     @JsonProperty("Data")
     private OBWriteDataDomesticStandingOrderConsentResponse3 data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse4.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteDomesticStandingOrderConsentResponse4
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticStandingOrderConsentResponse4 {
     @JsonProperty("Data")
     private OBWriteDomesticStandingOrderConsentResponse4Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse4Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticStandingOrderConsentResponse4Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticStandingOrderConsentResponse4Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse5.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteDomesticStandingOrderConsentResponse5
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticStandingOrderConsentResponse5 {
     @JsonProperty("Data")
     private OBWriteDomesticStandingOrderConsentResponse5Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse5Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse5Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticStandingOrderConsentResponse5Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticStandingOrderConsentResponse5Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse6.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse6.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteDomesticStandingOrderConsentResponse6
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticStandingOrderConsentResponse6 {
     @JsonProperty("Data")
     private OBWriteDomesticStandingOrderConsentResponse6Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse6Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse6Data.java
@@ -45,7 +45,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticStandingOrderConsentResponse6Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticStandingOrderConsentResponse6Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse6DataInitiation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderConsentResponse6DataInitiation.java
@@ -36,7 +36,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen", date = "2021-05-11T10:59:35.118Z[GMT]")
+@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen")
 public class OBWriteDomesticStandingOrderConsentResponse6DataInitiation {
     @JsonProperty("Frequency")
     private String frequency = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse1.java
@@ -32,7 +32,7 @@ import uk.org.openbanking.datamodel.common.Meta;
  * OBWriteDomesticStandingOrderResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticStandingOrderResponse1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse2.java
@@ -32,7 +32,7 @@ import uk.org.openbanking.datamodel.common.Meta;
  * OBWriteDomesticStandingOrderResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteDomesticStandingOrderResponse2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse3.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteDomesticStandingOrderResponse3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticStandingOrderResponse3 {
     @JsonProperty("Data")
     private OBWriteDataDomesticStandingOrderResponse3 data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse4.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteDomesticStandingOrderResponse4
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticStandingOrderResponse4 {
     @JsonProperty("Data")
     private OBWriteDomesticStandingOrderResponse4Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse4Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticStandingOrderResponse4Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticStandingOrderResponse4Data {
     @JsonProperty("DomesticStandingOrderId")
     private String domesticStandingOrderId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse5.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteDomesticStandingOrderResponse5
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticStandingOrderResponse5 {
     @JsonProperty("Data")
     private OBWriteDomesticStandingOrderResponse5Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse5Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse5Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticStandingOrderResponse5Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticStandingOrderResponse5Data {
     @JsonProperty("DomesticStandingOrderId")
     private String domesticStandingOrderId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse6.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse6.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteDomesticStandingOrderResponse6
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticStandingOrderResponse6 {
     @JsonProperty("Data")
     private OBWriteDomesticStandingOrderResponse6Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse6Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteDomesticStandingOrderResponse6Data.java
@@ -45,7 +45,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteDomesticStandingOrderResponse6Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteDomesticStandingOrderResponse6Data {
     @JsonProperty("DomesticStandingOrderId")
     private String domesticStandingOrderId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFile1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFile1.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteFile1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteFile1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFile2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFile2.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteFile2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteFile2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFile2Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFile2Data.java
@@ -41,7 +41,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteFile2Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteFile2Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFile2DataInitiation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFile2DataInitiation.java
@@ -35,7 +35,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
  * The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file.
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBWriteFile2DataInitiation {
     @JsonProperty("FileType")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsent1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsent1.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteFileConsent1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteFileConsent1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsent2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsent2.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteFileConsent2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteFileConsent2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsent3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsent3.java
@@ -40,7 +40,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteFileConsent3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteFileConsent3 {
     @JsonProperty("Data")
     private OBWriteFileConsent3Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsent3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsent3Data.java
@@ -38,7 +38,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteFileConsent3Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteFileConsent3Data {
     @JsonProperty("Initiation")
     private OBWriteFile2DataInitiation initiation = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse1.java
@@ -32,7 +32,7 @@ import uk.org.openbanking.datamodel.common.Meta;
  * OBWriteFileConsentResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteFileConsentResponse1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse2.java
@@ -32,7 +32,7 @@ import uk.org.openbanking.datamodel.common.Meta;
  * OBWriteFileConsentResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteFileConsentResponse2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse3.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteFileConsentResponse3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteFileConsentResponse3 {
     @JsonProperty("Data")
     private OBWriteFileConsentResponse3Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse3Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteFileConsentResponse3Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteFileConsentResponse3Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse4.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteFileConsentResponse4
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteFileConsentResponse4 {
     @JsonProperty("Data")
     private OBWriteFileConsentResponse4Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileConsentResponse4Data.java
@@ -45,7 +45,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteFileConsentResponse4Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteFileConsentResponse4Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileResponse1.java
@@ -32,7 +32,7 @@ import uk.org.openbanking.datamodel.common.Meta;
  * OBWriteFileResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteFileResponse1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileResponse2.java
@@ -32,7 +32,7 @@ import uk.org.openbanking.datamodel.common.Meta;
  * OBWriteFileResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteFileResponse2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileResponse2Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileResponse2Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteFileResponse2Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteFileResponse2Data {
     @JsonProperty("FilePaymentId")
     private String filePaymentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileResponse3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileResponse3.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteFileResponse3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteFileResponse3 {
     @JsonProperty("Data")
     private OBWriteFileResponse3Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileResponse3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFileResponse3Data.java
@@ -45,7 +45,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteFileResponse3Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteFileResponse3Data {
     @JsonProperty("FilePaymentId")
     private String filePaymentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFundsConfirmationResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFundsConfirmationResponse1.java
@@ -29,7 +29,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteFundsConfirmationResponse1
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBWriteFundsConfirmationResponse1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFundsConfirmationResponse1Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFundsConfirmationResponse1Data.java
@@ -27,7 +27,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
 /**
  * OBWriteFundsConfirmationResponse1Data
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBWriteFundsConfirmationResponse1Data {
     @JsonProperty("FundsAvailableResult")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFundsConfirmationResponse1DataFundsAvailableResult.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteFundsConfirmationResponse1DataFundsAvailableResult.java
@@ -44,7 +44,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Result of a funds availability check.
  */
 @ApiModel(description = "Result of a funds availability check.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteFundsConfirmationResponse1DataFundsAvailableResult {
     @JsonProperty("FundsAvailableDateTime")
     private DateTime fundsAvailableDateTime = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational1.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteInternational1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternational1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteInternational2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternational2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2Data.java
@@ -41,7 +41,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternational2Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternational2Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2DataInitiation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2DataInitiation.java
@@ -46,7 +46,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
  * The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment.
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternational2DataInitiation {
     @JsonProperty("InstructionIdentification")
     private String instructionIdentification = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2DataInitiationCreditor.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2DataInitiationCreditor.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBPostalAddress6;
  * Party to which an amount of money is due.
  */
 @ApiModel(description = "Party to which an amount of money is due.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternational2DataInitiationCreditor {
     @JsonProperty("Name")
     private String name = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2DataInitiationCreditorAgent.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2DataInitiationCreditorAgent.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBPostalAddress6;
  * Financial institution servicing an account for the creditor.
  */
 @ApiModel(description = "Financial institution servicing an account for the creditor.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternational2DataInitiationCreditorAgent {
     @JsonProperty("SchemeName")
     private String schemeName = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2DataInitiationExchangeRateInformation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational2DataInitiationExchangeRateInformation.java
@@ -45,7 +45,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Provides details on the currency exchange rate and contract.
  */
 @ApiModel(description = "Provides details on the currency exchange rate and contract.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternational2DataInitiationExchangeRateInformation {
     @JsonProperty("UnitCurrency")
     private String unitCurrency = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3.java
@@ -41,7 +41,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternational3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternational3 {
     @JsonProperty("Data")
     private OBWriteInternational3Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3Data.java
@@ -41,7 +41,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternational3Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternational3Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3DataInitiation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3DataInitiation.java
@@ -46,7 +46,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
  * The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment.
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternational3DataInitiation {
     @JsonProperty("InstructionIdentification")
     private String instructionIdentification = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3DataInitiationCreditor.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3DataInitiationCreditor.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBPostalAddress6;
  * Party to which an amount of money is due.
  */
 @ApiModel(description = "Party to which an amount of money is due.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternational3DataInitiationCreditor {
     @JsonProperty("Name")
     private String name = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3DataInitiationCreditorAgent.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3DataInitiationCreditorAgent.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBPostalAddress6;
  * Financial institution servicing an account for the creditor.
  */
 @ApiModel(description = "Financial institution servicing an account for the creditor.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternational3DataInitiationCreditorAgent {
     @JsonProperty("SchemeName")
     private String schemeName = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3DataInitiationExchangeRateInformation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternational3DataInitiationExchangeRateInformation.java
@@ -45,7 +45,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Provides details on the currency exchange rate and contract.
  */
 @ApiModel(description = "Provides details on the currency exchange rate and contract.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternational3DataInitiationExchangeRateInformation {
     @JsonProperty("UnitCurrency")
     private String unitCurrency = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent1.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteInternationalConsent1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalConsent1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent2.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteInternationalConsent2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalConsent2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent3.java
@@ -41,7 +41,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalConsent3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalConsent3 {
     @JsonProperty("Data")
     private OBWriteInternationalConsent3Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent3Data.java
@@ -40,7 +40,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalConsent3Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalConsent3Data {
     @JsonProperty("Initiation")
     private OBWriteInternational2DataInitiation initiation = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent4.java
@@ -41,7 +41,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalConsent4
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalConsent4 {
     @JsonProperty("Data")
     private OBWriteInternationalConsent4Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent4Data.java
@@ -40,7 +40,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalConsent4Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalConsent4Data {
     @JsonProperty("Initiation")
     private OBWriteInternational3DataInitiation initiation = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent5.java
@@ -41,7 +41,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalConsent5
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalConsent5 {
     @JsonProperty("Data")
     private OBWriteInternationalConsent5Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent5Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsent5Data.java
@@ -38,7 +38,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalConsent5Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalConsent5Data {
 
     @JsonProperty("ReadRefundAccount")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse1.java
@@ -33,7 +33,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteInternationalConsentResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalConsentResponse1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse2.java
@@ -33,7 +33,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteInternationalConsentResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalConsentResponse2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse3.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalConsentResponse3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalConsentResponse3 {
     @JsonProperty("Data")
     private OBWriteInternationalConsentResponse3Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse3Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalConsentResponse3Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalConsentResponse3Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse3DataExchangeRateInformation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse3DataExchangeRateInformation.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Further detailed information on the exchange rate that has been used in the payment transaction.
  */
 @ApiModel(description = "Further detailed information on the exchange rate that has been used in the payment transaction.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalConsentResponse3DataExchangeRateInformation {
     @JsonProperty("UnitCurrency")
     private String unitCurrency = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse4.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalConsentResponse4
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalConsentResponse4 {
     @JsonProperty("Data")
     private OBWriteInternationalConsentResponse4Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse4Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalConsentResponse4Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalConsentResponse4Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse4DataExchangeRateInformation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse4DataExchangeRateInformation.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Further detailed information on the exchange rate that has been used in the payment transaction.
  */
 @ApiModel(description = "Further detailed information on the exchange rate that has been used in the payment transaction.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalConsentResponse4DataExchangeRateInformation {
     @JsonProperty("UnitCurrency")
     private String unitCurrency = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse5.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalConsentResponse5
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalConsentResponse5 {
     @JsonProperty("Data")
     private OBWriteInternationalConsentResponse5Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse5Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse5Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalConsentResponse5Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalConsentResponse5Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse5DataExchangeRateInformation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse5DataExchangeRateInformation.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Further detailed information on the exchange rate that has been used in the payment transaction.
  */
 @ApiModel(description = "Further detailed information on the exchange rate that has been used in the payment transaction.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalConsentResponse5DataExchangeRateInformation {
     @JsonProperty("UnitCurrency")
     private String unitCurrency = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse6.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse6.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalConsentResponse6
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalConsentResponse6 {
     @JsonProperty("Data")
     private OBWriteInternationalConsentResponse6Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse6Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse6Data.java
@@ -45,7 +45,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalConsentResponse6Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalConsentResponse6Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse6DataExchangeRateInformation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalConsentResponse6DataExchangeRateInformation.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Further detailed information on the exchange rate that has been used in the payment transaction.
  */
 @ApiModel(description = "Further detailed information on the exchange rate that has been used in the payment transaction.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalConsentResponse6DataExchangeRateInformation {
     @JsonProperty("UnitCurrency")
     private String unitCurrency = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalRefundResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalRefundResponse1.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteInternationalRefundResponse1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalRefundResponse1 {
     @JsonProperty("Data")
     private OBWriteInternationalRefundResponse1Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalRefundResponse1Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalRefundResponse1Data.java
@@ -39,7 +39,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalRefundResponse1Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalRefundResponse1Data {
     @JsonProperty("Refund")
     private OBWriteInternationalRefundResponse1DataRefund refund = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalRefundResponse1DataRefund.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalRefundResponse1DataRefund.java
@@ -40,7 +40,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalRefundResponse1DataRefund
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalRefundResponse1DataRefund {
     @JsonProperty("Creditor")
     private OBWriteInternationalRefundResponse1DataRefundCreditor creditor = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalRefundResponse1DataRefundAgent.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalRefundResponse1DataRefundAgent.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBPostalAddress6;
  * Set of elements used to uniquely and unambiguously identify a financial institution or a branch of a financial institution.
  */
 @ApiModel(description = "Set of elements used to uniquely and unambiguously identify a financial institution or a branch of a financial institution.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalRefundResponse1DataRefundAgent {
     @JsonProperty("SchemeName")
     private String schemeName = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalRefundResponse1DataRefundCreditor.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalRefundResponse1DataRefundCreditor.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBPostalAddress6;
  * Set of elements used to identify a person or an organisation.
  */
 @ApiModel(description = "Set of elements used to identify a person or an organisation.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalRefundResponse1DataRefundCreditor {
     @JsonProperty("Name")
     private String name = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse1.java
@@ -32,7 +32,7 @@ import uk.org.openbanking.datamodel.common.Meta;
  * OBWriteInternationalResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalResponse1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse2.java
@@ -32,7 +32,7 @@ import uk.org.openbanking.datamodel.common.Meta;
  * OBWriteInternationalResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalResponse2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse3.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteInternationalResponse3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalResponse3 {
     @JsonProperty("Data")
     private OBWriteInternationalResponse3Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse3Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalResponse3Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalResponse3Data {
     @JsonProperty("InternationalPaymentId")
     private String internationalPaymentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse4.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteInternationalResponse4
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalResponse4 {
     @JsonProperty("Data")
     private OBWriteInternationalResponse4Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse4Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalResponse4Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00", comments = "updated at 2020-12-23T13:31:35.768Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalResponse4Data {
     @JsonProperty("InternationalPaymentId")
     private String internationalPaymentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse4DataRefund.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse4DataRefund.java
@@ -40,7 +40,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalResponse4DataRefund
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-12-23T13:31:35.768Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 
 
 public class OBWriteInternationalResponse4DataRefund {

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse4DataRefundAgent.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse4DataRefundAgent.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBPostalAddress6;
  * Set of elements used to uniquely and unambiguously identify a financial institution or a branch of a financial institution.
  */
 @ApiModel(description = "Set of elements used to uniquely and unambiguously identify a financial institution or a branch of a financial institution.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-12-23T13:31:35.768Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 
 
 public class OBWriteInternationalResponse4DataRefundAgent {

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse4DataRefundCreditor.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse4DataRefundCreditor.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBPostalAddress6;
  * Set of elements used to identify a person or an organisation.
  */
 @ApiModel(description = "Set of elements used to identify a person or an organisation.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-12-23T13:31:35.768Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 
 
 public class OBWriteInternationalResponse4DataRefundCreditor {

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse5.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteInternationalResponse5
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalResponse5 {
     @JsonProperty("Data")
     private OBWriteInternationalResponse5Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse5Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse5Data.java
@@ -45,7 +45,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalResponse5Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalResponse5Data {
     @JsonProperty("InternationalPaymentId")
     private String internationalPaymentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse5DataRefund.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse5DataRefund.java
@@ -40,7 +40,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalResponse5DataRefund
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalResponse5DataRefund {
     @JsonProperty("Creditor")
     private OBWriteInternationalResponse5DataRefundCreditor creditor = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse5DataRefundAgent.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse5DataRefundAgent.java
@@ -30,7 +30,7 @@ import uk.org.openbanking.datamodel.common.OBPostalAddress6;
  * Set of elements used to uniquely and unambiguously identify a financial institution or a branch of a financial institution.
  */
 @ApiModel(description = "Set of elements used to uniquely and unambiguously identify a financial institution or a branch of a financial institution.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalResponse5DataRefundAgent {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse5DataRefundCreditor.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalResponse5DataRefundCreditor.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBPostalAddress6;
  * Set of elements used to identify a person or an organisation.
  */
 @ApiModel(description = "Set of elements used to identify a person or an organisation.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalResponse5DataRefundCreditor {
     @JsonProperty("Name")
     private String name = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled1.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteInternationalScheduled1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalScheduled1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled2.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteInternationalScheduled2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalScheduled2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled2Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled2Data.java
@@ -41,7 +41,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalScheduled2Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduled2Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled2DataInitiation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled2DataInitiation.java
@@ -48,7 +48,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
  * The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment.
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduled2DataInitiation {
     @JsonProperty("InstructionIdentification")
     private String instructionIdentification = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled3.java
@@ -41,7 +41,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalScheduled3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduled3 {
     @JsonProperty("Data")
     private OBWriteInternationalScheduled3Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled3Data.java
@@ -41,7 +41,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalScheduled3Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduled3Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled3DataInitiation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduled3DataInitiation.java
@@ -48,7 +48,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
  * The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment.
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduled3DataInitiation {
     @JsonProperty("InstructionIdentification")
     private String instructionIdentification = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent1.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteInternationalScheduledConsent1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalScheduledConsent1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent2.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteInternationalScheduledConsent2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalScheduledConsent2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent3.java
@@ -41,7 +41,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalScheduledConsent3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduledConsent3 {
     @JsonProperty("Data")
     private OBWriteInternationalScheduledConsent3Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent3Data.java
@@ -40,7 +40,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalScheduledConsent3Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduledConsent3Data {
     @JsonProperty("Permission")
     private OBExternalPermissions2Code permission = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent4.java
@@ -41,7 +41,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalScheduledConsent4
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduledConsent4 {
     @JsonProperty("Data")
     private OBWriteInternationalScheduledConsent4Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent4Data.java
@@ -40,7 +40,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalScheduledConsent4Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduledConsent4Data {
 
     @JsonProperty("Permission")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent5.java
@@ -41,7 +41,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalScheduledConsent5
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduledConsent5 {
     @JsonProperty("Data")
     private OBWriteInternationalScheduledConsent5Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent5Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsent5Data.java
@@ -38,7 +38,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalScheduledConsent5Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduledConsent5Data {
 
     @JsonProperty("Permission")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse1.java
@@ -33,7 +33,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteInternationalScheduledConsentResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalScheduledConsentResponse1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse2.java
@@ -33,7 +33,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteInternationalScheduledConsentResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalScheduledConsentResponse2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse3.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalScheduledConsentResponse3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduledConsentResponse3 {
     @JsonProperty("Data")
     private OBWriteInternationalScheduledConsentResponse3Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse3Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalScheduledConsentResponse3Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduledConsentResponse3Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse4.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalScheduledConsentResponse4
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduledConsentResponse4 {
     @JsonProperty("Data")
     private OBWriteInternationalScheduledConsentResponse4Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse4Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalScheduledConsentResponse4Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduledConsentResponse4Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse5.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalScheduledConsentResponse5
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduledConsentResponse5 {
     @JsonProperty("Data")
     private OBWriteInternationalScheduledConsentResponse5Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse5Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse5Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalScheduledConsentResponse5Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduledConsentResponse5Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse6.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse6.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalScheduledConsentResponse6
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduledConsentResponse6 {
     @JsonProperty("Data")
     private OBWriteInternationalScheduledConsentResponse6Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse6Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse6Data.java
@@ -45,7 +45,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalScheduledConsentResponse6Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduledConsentResponse6Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse6DataInitiation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse6DataInitiation.java
@@ -35,7 +35,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
  * The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment.
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalScheduledConsentResponse6DataInitiation {
     @JsonProperty("InstructionIdentification")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse6DataInitiationCreditor.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledConsentResponse6DataInitiationCreditor.java
@@ -33,7 +33,7 @@ import uk.org.openbanking.datamodel.common.OBPostalAddress6;
  */
 @ApiModel(description = "Party to which an amount of money is due.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-08-20T10:23:11.959Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 public class OBWriteInternationalScheduledConsentResponse6DataInitiationCreditor {
     @JsonProperty("Name")
     private String name = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse1.java
@@ -32,7 +32,7 @@ import uk.org.openbanking.datamodel.common.Meta;
  * OBWriteInternationalScheduledResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalScheduledResponse1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse2.java
@@ -32,7 +32,7 @@ import uk.org.openbanking.datamodel.common.Meta;
  * OBWriteInternationalScheduledResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalScheduledResponse2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse3.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteInternationalScheduledResponse3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduledResponse3 {
     @JsonProperty("Data")
     private OBWriteInternationalScheduledResponse3Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse3Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalScheduledResponse3Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduledResponse3Data {
     @JsonProperty("InternationalScheduledPaymentId")
     private String internationalScheduledPaymentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse4.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteInternationalScheduledResponse4
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduledResponse4 {
     @JsonProperty("Data")
     private OBWriteInternationalScheduledResponse4Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse4Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalScheduledResponse4Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduledResponse4Data {
     @JsonProperty("InternationalScheduledPaymentId")
     private String internationalScheduledPaymentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse5.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteInternationalScheduledResponse5
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduledResponse5 {
     @JsonProperty("Data")
     private OBWriteInternationalScheduledResponse5Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse5Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse5Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalScheduledResponse5Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00", comments = "updated at 2020-12-23T13:31:35.768Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduledResponse5Data {
     @JsonProperty("InternationalScheduledPaymentId")
     private String internationalScheduledPaymentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse6.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse6.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteInternationalScheduledResponse6
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduledResponse6 {
     @JsonProperty("Data")
     private OBWriteInternationalScheduledResponse6Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse6Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalScheduledResponse6Data.java
@@ -45,7 +45,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalScheduledResponse6Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalScheduledResponse6Data {
     @JsonProperty("InternationalScheduledPaymentId")
     private String internationalScheduledPaymentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder1.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteInternationalStandingOrder1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalStandingOrder1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder2.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteInternationalStandingOrder2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalStandingOrder2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder3.java
@@ -41,7 +41,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalStandingOrder3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrder3 {
     @JsonProperty("Data")
     private OBWriteDataInternationalStandingOrder3 data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder3Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder3Data.java
@@ -41,7 +41,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalStandingOrder3Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrder3Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder3DataInitiation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder3DataInitiation.java
@@ -48,7 +48,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
  * The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order.
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrder3DataInitiation {
     @JsonProperty("Frequency")
     private String frequency = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder3DataInitiationCreditorAccount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder3DataInitiationCreditorAccount.java
@@ -42,7 +42,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Provides the details to identify the beneficiary account.
  */
 @ApiModel(description = "Provides the details to identify the beneficiary account.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrder3DataInitiationCreditorAccount {
     @JsonProperty("SchemeName")
     private String schemeName = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder3DataInitiationCreditorAgent.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder3DataInitiationCreditorAgent.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBPostalAddress6;
  * Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account.
  */
 @ApiModel(description = "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrder3DataInitiationCreditorAgent {
     @JsonProperty("SchemeName")
     private String schemeName = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder4.java
@@ -41,7 +41,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalStandingOrder4
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrder4 {
     @JsonProperty("Data")
     private OBWriteInternationalStandingOrder4Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder4Data.java
@@ -41,7 +41,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalStandingOrder4Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrder4Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder4DataInitiation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder4DataInitiation.java
@@ -46,7 +46,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
  * The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order.
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrder4DataInitiation {
     @JsonProperty("Frequency")
     private String frequency = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder4DataInitiationCreditorAccount.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder4DataInitiationCreditorAccount.java
@@ -29,7 +29,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Provides the details to identify the beneficiary account.
  */
 @ApiModel(description = "Provides the details to identify the beneficiary account.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalStandingOrder4DataInitiationCreditorAccount {
     @JsonProperty("SchemeName")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder4DataInitiationCreditorAgent.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrder4DataInitiationCreditorAgent.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBPostalAddress6;
  * Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account.
  */
 @ApiModel(description = "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account. This is the servicer of the beneficiary account.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrder4DataInitiationCreditorAgent {
     @JsonProperty("SchemeName")
     private String schemeName = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent1.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteInternationalStandingOrderConsent1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalStandingOrderConsent1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent2.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteInternationalStandingOrderConsent2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalStandingOrderConsent2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent3.java
@@ -41,7 +41,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalStandingOrderConsent3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderConsent3 {
     @JsonProperty("Data")
     private OBWriteDataInternationalStandingOrderConsent3 data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent4.java
@@ -41,7 +41,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalStandingOrderConsent4
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderConsent4 {
     @JsonProperty("Data")
     private OBWriteInternationalStandingOrderConsent4Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent4Data.java
@@ -40,7 +40,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalStandingOrderConsent4Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderConsent4Data {
     @JsonProperty("Permission")
     private OBExternalPermissions2Code permission = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent5.java
@@ -41,7 +41,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalStandingOrderConsent5
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderConsent5 {
     @JsonProperty("Data")
     private OBWriteInternationalStandingOrderConsent5Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent5Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent5Data.java
@@ -40,7 +40,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalStandingOrderConsent5Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderConsent5Data {
 
     @JsonProperty("Permission")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent6.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent6.java
@@ -41,7 +41,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalStandingOrderConsent6
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderConsent6 {
     @JsonProperty("Data")
     private OBWriteInternationalStandingOrderConsent6Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent6Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsent6Data.java
@@ -38,7 +38,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalStandingOrderConsent6Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderConsent6Data {
 
     @JsonProperty("Permission")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse1.java
@@ -33,7 +33,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteInternationalStandingOrderConsentResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalStandingOrderConsentResponse1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse2.java
@@ -33,7 +33,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
  * OBWriteInternationalStandingOrderConsentResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalStandingOrderConsentResponse2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse3.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalStandingOrderConsentResponse3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderConsentResponse3 {
     @JsonProperty("Data")
     private OBWriteDataInternationalStandingOrderConsentResponse3 data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse4.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalStandingOrderConsentResponse4
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderConsentResponse4 {
     @JsonProperty("Data")
     private OBWriteInternationalStandingOrderConsentResponse4Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse4Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalStandingOrderConsentResponse4Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderConsentResponse4Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse5.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalStandingOrderConsentResponse5
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderConsentResponse5 {
     @JsonProperty("Data")
     private OBWriteInternationalStandingOrderConsentResponse5Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse5Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse5Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalStandingOrderConsentResponse5Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderConsentResponse5Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse6.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse6.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalStandingOrderConsentResponse6
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderConsentResponse6 {
     @JsonProperty("Data")
     private OBWriteInternationalStandingOrderConsentResponse6Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse6Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse6Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalStandingOrderConsentResponse6Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderConsentResponse6Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse7.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse7.java
@@ -43,7 +43,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBWriteInternationalStandingOrderConsentResponse7
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderConsentResponse7 {
     @JsonProperty("Data")
     private OBWriteInternationalStandingOrderConsentResponse7Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse7Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse7Data.java
@@ -45,7 +45,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalStandingOrderConsentResponse7Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderConsentResponse7Data {
     @JsonProperty("ConsentId")
     private String consentId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse7DataInitiation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderConsentResponse7DataInitiation.java
@@ -37,7 +37,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
  */
 @ApiModel(description = "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen", date = "2021-05-11T10:59:35.118Z[GMT]")
+@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen")
 
 public class OBWriteInternationalStandingOrderConsentResponse7DataInitiation {
     @JsonProperty("Frequency")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse1.java
@@ -32,7 +32,7 @@ import uk.org.openbanking.datamodel.common.Meta;
  * OBWriteInternationalStandingOrderResponse1
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalStandingOrderResponse1 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse2.java
@@ -32,7 +32,7 @@ import uk.org.openbanking.datamodel.common.Meta;
  * OBWriteInternationalStandingOrderResponse2
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2019-01-28T11:15:38.268Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalStandingOrderResponse2 {
     @JsonProperty("Data")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse3.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse3.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteInternationalStandingOrderResponse3
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-05-23T11:45:43.255+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderResponse3 {
     @JsonProperty("Data")
     private OBWriteDataInternationalStandingOrderResponse3 data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse4.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse4.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteInternationalStandingOrderResponse4
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderResponse4 {
     @JsonProperty("Data")
     private OBWriteInternationalStandingOrderResponse4Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse4Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse4Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalStandingOrderResponse4Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderResponse4Data {
     @JsonProperty("InternationalStandingOrderId")
     private String internationalStandingOrderId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse5.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse5.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteInternationalStandingOrderResponse5
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderResponse5 {
     @JsonProperty("Data")
     private OBWriteInternationalStandingOrderResponse5Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse5Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse5Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalStandingOrderResponse5Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T11:45:24.725+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderResponse5Data {
     @JsonProperty("InternationalStandingOrderId")
     private String internationalStandingOrderId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse6.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse6.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteInternationalStandingOrderResponse6
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderResponse6 {
     @JsonProperty("Data")
     private OBWriteInternationalStandingOrderResponse6Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse6Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse6Data.java
@@ -47,7 +47,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalStandingOrderResponse6Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:14:13.501+01:00", comments = "updated at 2020-12-23T13:31:35.768Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderResponse6Data {
     @JsonProperty("InternationalStandingOrderId")
     private String internationalStandingOrderId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse7.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse7.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWriteInternationalStandingOrderResponse7
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderResponse7 {
     @JsonProperty("Data")
     private OBWriteInternationalStandingOrderResponse7Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse7Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse7Data.java
@@ -45,7 +45,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWriteInternationalStandingOrderResponse7Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2020-05-19T14:52:44.811+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWriteInternationalStandingOrderResponse7Data {
     @JsonProperty("InternationalStandingOrderId")
     private String internationalStandingOrderId = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse7DataRefund.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse7DataRefund.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
  * OBWriteInternationalStandingOrderResponse7DataRefund
  */
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-08-20T10:23:11.959Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 public class OBWriteInternationalStandingOrderResponse7DataRefund {
     @JsonProperty("Creditor")
     private OBWriteInternationalStandingOrderResponse7DataRefundCreditor creditor = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse7DataRefundCreditor.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWriteInternationalStandingOrderResponse7DataRefundCreditor.java
@@ -33,7 +33,7 @@ import uk.org.openbanking.datamodel.common.OBPostalAddress6;
  */
 @ApiModel(description = "Set of elements used to identify a person or an organisation.")
 @Validated
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-08-20T10:23:11.959Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 public class OBWriteInternationalStandingOrderResponse7DataRefundCreditor {
     @JsonProperty("Name")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWritePaymentDetailsResponse1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWritePaymentDetailsResponse1.java
@@ -42,7 +42,7 @@ import uk.org.openbanking.datamodel.common.Meta;
 /**
  * OBWritePaymentDetailsResponse1
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWritePaymentDetailsResponse1 {
     @JsonProperty("Data")
     private OBWritePaymentDetailsResponse1Data data = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWritePaymentDetailsResponse1Data.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWritePaymentDetailsResponse1Data.java
@@ -41,7 +41,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBWritePaymentDetailsResponse1Data
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2019-06-13T16:03:12.161+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen")
 public class OBWritePaymentDetailsResponse1Data {
     @JsonProperty("PaymentStatus")
     private List<OBWritePaymentDetailsResponse1DataPaymentStatus> paymentStatus = null;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWritePaymentDetailsResponse1DataPaymentStatus.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWritePaymentDetailsResponse1DataPaymentStatus.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Payment status details.
  */
 @ApiModel(description = "Payment status details.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBWritePaymentDetailsResponse1DataPaymentStatus {
     @JsonProperty("PaymentTransactionId")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWritePaymentDetailsResponse1DataStatusDetail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/payment/OBWritePaymentDetailsResponse1DataStatusDetail.java
@@ -31,7 +31,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Payment status details as per underlying Payment Rail.
  */
 @ApiModel(description = "Payment status details as per underlying Payment Rail.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-05-20T11:30:55.433304+01:00[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 
 public class OBWritePaymentDetailsResponse1DataStatusDetail {
     @JsonProperty("LocalInstrument")

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBCashAccountDebtorWithName.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBCashAccountDebtorWithName.java
@@ -27,7 +27,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBCashAccountDebtorWithName
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBCashAccountDebtorWithName {
     @JsonProperty("SchemeName")
     private String schemeName;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBCharge2.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBCharge2.java
@@ -28,7 +28,7 @@ import uk.org.openbanking.datamodel.common.OBChargeBearerType1Code;
 /**
  * OBCharge2
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBCharge2 {
     @JsonProperty("ChargeBearer")
     private OBChargeBearerType1Code chargeBearer;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPConsentRequest.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPConsentRequest.java
@@ -28,7 +28,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBDomesticVRPConsentRequest
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBDomesticVRPConsentRequest {
     @JsonProperty("Data")
     private OBDomesticVRPConsentRequestData data;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPConsentRequestData.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPConsentRequestData.java
@@ -29,7 +29,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBDomesticVRPConsentRequestData
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBDomesticVRPConsentRequestData {
     /**
      * Indicates whether information about RefundAccount should be included in the payment response.

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPConsentResponseData.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPConsentResponseData.java
@@ -32,7 +32,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBDomesticVRPConsentResponseData
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBDomesticVRPConsentResponseData {
     /**
      * Indicates whether information about RefundAccount should be included in the payment response.

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPControlParameters.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPControlParameters.java
@@ -33,7 +33,7 @@ import uk.org.openbanking.datamodel.common.OBActiveOrHistoricCurrencyAndAmount;
 /**
  * OBDomesticVRPControlParameters
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBDomesticVRPControlParameters {
     @JsonProperty("ValidFromDateTime")
     @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE_TIME)

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPControlParametersPeriodicLimits.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPControlParametersPeriodicLimits.java
@@ -30,7 +30,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBDomesticVRPControlParametersPeriodicLimits
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBDomesticVRPControlParametersPeriodicLimits {
     /**
      * ^ Period type for this period limit

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPDetails.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPDetails.java
@@ -26,7 +26,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBDomesticVRPDetails
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBDomesticVRPDetails {
     @JsonProperty("Data")
     private OBDomesticVRPDetailsData data;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPDetailsData.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPDetailsData.java
@@ -28,7 +28,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBDomesticVRPDetailsData
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBDomesticVRPDetailsData {
     @JsonProperty("PaymentStatus")
     @Valid

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPDetailsDataPaymentStatus.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPDetailsDataPaymentStatus.java
@@ -32,7 +32,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBDomesticVRPDetailsDataPaymentStatus
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBDomesticVRPDetailsDataPaymentStatus {
     @JsonProperty("PaymentTransactionId")
     private String paymentTransactionId;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPDetailsDataStatusDetail.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPDetailsDataStatusDetail.java
@@ -29,7 +29,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBDomesticVRPDetailsDataStatusDetail
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBDomesticVRPDetailsDataStatusDetail {
     @JsonProperty("LocalInstrument")
     private String localInstrument;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPInitiation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPInitiation.java
@@ -28,7 +28,7 @@ import uk.org.openbanking.datamodel.common.OBCashAccountCreditor3;
 /**
  * OBDomesticVRPInitiation
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBDomesticVRPInitiation {
     @JsonProperty("DebtorAccount")
     private OBCashAccountDebtorWithName debtorAccount;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPInitiationRemittanceInformation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPInitiationRemittanceInformation.java
@@ -28,7 +28,7 @@ import io.swagger.annotations.ApiModelProperty;
  * ^ Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts&#39; receivable system.
  */
 @ApiModel(description = "^ Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBDomesticVRPInitiationRemittanceInformation {
     @JsonProperty("Unstructured")
     private String unstructured;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPInstruction.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPInstruction.java
@@ -32,7 +32,7 @@ import uk.org.openbanking.datamodel.common.OBSupplementaryData1;
 /**
  * OBDomesticVRPInstruction
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBDomesticVRPInstruction {
     @JsonProperty("InstructionIdentification")
     private String instructionIdentification;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPRequest.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPRequest.java
@@ -28,7 +28,7 @@ import uk.org.openbanking.datamodel.common.OBRisk1;
 /**
  * OBDomesticVRPRequest
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBDomesticVRPRequest {
     @JsonProperty("Data")
     private OBDomesticVRPRequestData data;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPRequestData.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPRequestData.java
@@ -28,7 +28,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBDomesticVRPRequestData
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBDomesticVRPRequestData {
     @JsonProperty("ConsentId")
     private String consentId;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPResponseData.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPResponseData.java
@@ -34,7 +34,7 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * OBDomesticVRPResponseData
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBDomesticVRPResponseData {
     @JsonProperty("DomesticVRPId")
     private String domesticVRPId;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPResponseDataCharges.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPResponseDataCharges.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBChargeBearerType1Code;
  * Set of elements used to provide details of a charge for the payment initiation.
  */
 @ApiModel(description = "Set of elements used to provide details of a charge for the payment initiation.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBDomesticVRPResponseDataCharges {
     @JsonProperty("ChargeBearer")
     private OBChargeBearerType1Code chargeBearer;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBPAFundsAvailableResult1.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBPAFundsAvailableResult1.java
@@ -33,7 +33,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Availability result, clearly indicating the availability of funds given the Amount in the request.
  */
 @ApiModel(description = "Availability result, clearly indicating the availability of funds given the Amount in the request.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBPAFundsAvailableResult1 {
     @JsonProperty("FundsAvailableDateTime")
     @org.springframework.format.annotation.DateTimeFormat(iso = org.springframework.format.annotation.DateTimeFormat.ISO.DATE_TIME)

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBVRPFundsConfirmationRequest.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBVRPFundsConfirmationRequest.java
@@ -28,7 +28,7 @@ import io.swagger.annotations.ApiModelProperty;
  * The OBVRPFundsConfirmationRequest object must be used to request funds availability for a specific amount in the Debtor Account included in the VRP consents.
  */
 @ApiModel(description = "The OBVRPFundsConfirmationRequest object must be used to request funds availability for a specific amount in the Debtor Account included in the VRP consents.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBVRPFundsConfirmationRequest {
     @JsonProperty("Data")
     private OBVRPFundsConfirmationRequestData data;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBVRPFundsConfirmationRequestData.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBVRPFundsConfirmationRequestData.java
@@ -29,7 +29,7 @@ import uk.org.openbanking.datamodel.common.OBActiveOrHistoricCurrencyAndAmount;
 /**
  * OBVRPFundsConfirmationRequestData
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBVRPFundsConfirmationRequestData {
     @JsonProperty("ConsentId")
     private String consentId;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBVRPFundsConfirmationResponse.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBVRPFundsConfirmationResponse.java
@@ -28,7 +28,7 @@ import io.swagger.annotations.ApiModelProperty;
  * The confirmation of funds response contains the result of a funds availability check.
  */
 @ApiModel(description = "The confirmation of funds response contains the result of a funds availability check.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBVRPFundsConfirmationResponse {
     @JsonProperty("Data")
     private OBVRPFundsConfirmationResponseData data;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBVRPFundsConfirmationResponseData.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBVRPFundsConfirmationResponseData.java
@@ -31,7 +31,7 @@ import uk.org.openbanking.datamodel.common.OBActiveOrHistoricCurrencyAndAmount;
 /**
  * OBVRPFundsConfirmationResponseData
  */
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBVRPFundsConfirmationResponseData {
     @JsonProperty("FundsConfirmationId")
     private String fundsConfirmationId;

--- a/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBVRPRemittanceInformation.java
+++ b/securebanking-openbanking-uk-obie-datamodel/src/main/java/uk/org/openbanking/datamodel/vrp/OBVRPRemittanceInformation.java
@@ -28,7 +28,7 @@ import io.swagger.annotations.ApiModelProperty;
  * Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts&#39; receivable system.
  */
 @ApiModel(description = "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system.")
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2022-02-01T10:31:25.778538Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 public class OBVRPRemittanceInformation {
     @JsonProperty("Unstructured")
     private String unstructured;


### PR DESCRIPTION
Removing remaining timestamps which were missed from commit: b0000a1d, PR: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk/pull/52

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/451